### PR TITLE
[BD-19] Resolves illegal_argument_exception error for bulk method

### DIFF
--- a/.travis/elasticsearch.yml
+++ b/.travis/elasticsearch.yml
@@ -2,3 +2,4 @@ network.host: 0.0.0.0
 cluster.routing.allocation.disk.watermark.low: 150mb
 cluster.routing.allocation.disk.watermark.high: 100mb
 cluster.routing.allocation.disk.watermark.flood_stage: 50mb
+rest.action.multi.allow_explicit_index: true


### PR DESCRIPTION
**Description:** resolves error
```
Elasticsearch::Transport::Transport::Errors::BadRequest: [400] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"explicit index in bulk is not allowed"}],"type":"illegal_argument_exception","reason":"explicit index in bulk is not allowed"},"status":400}
      /edx/app/forum/cs_comments_service/models/user.rb:  200:in `retire_all_content'
        /edx/app/forum/cs_comments_service/api/users.rb:   94:in `block in <top(required)>'
<truncated 35 additional frames>
/edx/app/forum/cs_comments_service/bin/unicorn:16:in `load'
/edx/app/forum/cs_comments_service/bin/unicorn:16:in `<main>'
```