### PR TITLE
AA-303: Adding endpoint to return if a user has ever posted

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -19,6 +19,14 @@ get "#{APIPREFIX}/users/:user_id" do |user_id|
   end
 end
 
+get "#{APIPREFIX}/users/:user_id/content_exists" do |user_id|
+  begin
+    Content.where(author_id: user_id).exists?.to_json
+  rescue Mongoid::Errors::DocumentNotFound
+    error 404
+  end
+end
+
 get "#{APIPREFIX}/users/:user_id/active_threads" do |user_id|
   return {}.to_json if not params["course_id"]
 


### PR DESCRIPTION
This will check the Content table which stores both threads and
comments on threads. So if a user has created a post (thread) or commented
on one (comment), we will catch it.

The current use case for this is for the first Discussion milestone for
learners where we shhow them a celebration modal after their first
discussion post. In order to know if they have posted before, we hit
this endpoint.