### PR TITLE
feat: Add support for specifying edit and close reasons [BD-38] [TNL-8842] [BB-5011]

### DIFF
--- a/api/comments.rb
+++ b/api/comments.rb
@@ -19,6 +19,16 @@ put "#{APIPREFIX}/comments/:comment_id" do |comment_id|
       updated_content["endorsement"] = new_endorsed_val ? endorsement : nil
     end
   end
+  if updated_content.has_key? BODY and updated_content[BODY] != comment.body
+    edit_reason_code = params.fetch("edit_reason_code", nil)
+    comment.edit_history.build(
+      original_body: comment.body,
+      author: user,
+      reason_code: edit_reason_code,
+      editor_username: user.username,
+    )
+    comment.save
+  end
   comment.update_attributes(updated_content)
   if comment.errors.any?
     error 400, comment.errors.full_messages.to_json

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -2,6 +2,7 @@ require 'logger'
 require_relative 'concerns/searchable'
 require_relative 'content'
 require_relative 'constants'
+require_relative 'edit_history'
 
 logger = Logger.new(STDOUT)
 logger.level = Logger::WARN
@@ -52,7 +53,8 @@ class Comment < Content
   end
 
   belongs_to :comment_thread, index: true
-  belongs_to :author, class_name: 'User', index: true
+  belongs_to :author, class_name: 'User', inverse_of: :comments, index: true
+  embeds_many :edit_history, cascade_callbacks: true
 
   attr_accessible :body, :course_id, :anonymous, :anonymous_to_peers, :endorsed, :endorsement, :retired_username
 
@@ -108,6 +110,7 @@ class Comment < Content
                 "username" => author_username,
                 "depth" => depth,
                 "closed" => comment_thread.nil? ? false : comment_thread.closed,
+                "edit_history" => edit_history.map(&:to_hash),
                 "thread_id" => comment_thread_id,
                 "parent_id" => parent_ids[-1],
                 "commentable_id" => comment_thread.nil? ? nil : comment_thread.commentable_id,

--- a/models/constants.rb
+++ b/models/constants.rb
@@ -29,5 +29,11 @@ EXTERNAL_ID = "external_id".freeze
 COMMENT = "comment".freeze
 THREAD = "thread".freeze
 
+REASON_CODE = "reason_code".freeze
+CLOSE_REASON_CODE = "close_reason_code".freeze
+EDIT_REASON_CODE = "edit_reason_code".freeze
+ORIGINAL_BODY = "original_body".freeze
+EDIT_HISTORY = "edit_history".freeze
+
 RETIRED_TITLE = "[deleted]".freeze
 RETIRED_BODY = "[deleted]".freeze

--- a/models/constants.rb
+++ b/models/constants.rb
@@ -34,6 +34,8 @@ CLOSE_REASON_CODE = "close_reason_code".freeze
 EDIT_REASON_CODE = "edit_reason_code".freeze
 ORIGINAL_BODY = "original_body".freeze
 EDIT_HISTORY = "edit_history".freeze
+EDITOR_USERNAME = "editor_username".freeze
+
 
 RETIRED_TITLE = "[deleted]".freeze
 RETIRED_BODY = "[deleted]".freeze

--- a/models/edit_history.rb
+++ b/models/edit_history.rb
@@ -1,0 +1,16 @@
+
+class EditHistory
+  include Mongoid::Document
+  include Mongoid::Timestamps::Created
+
+  field :original_body, type: String
+  field :reason_code, type: String
+  field :editor_username, type: String
+
+  belongs_to :author, class_name: 'User', inverse_of: :comment_edits
+
+  embedded_in :comment
+  def to_hash
+    as_document.slice(ORIGINAL_BODY, REASON_CODE, "editor_username", CREATED_AT)
+  end
+end

--- a/models/edit_history.rb
+++ b/models/edit_history.rb
@@ -11,6 +11,6 @@ class EditHistory
 
   embedded_in :comment
   def to_hash
-    as_document.slice(ORIGINAL_BODY, REASON_CODE, "editor_username", CREATED_AT)
+    as_document.slice(ORIGINAL_BODY, REASON_CODE, EDITOR_USERNAME, CREATED_AT)
   end
 end

--- a/models/user.rb
+++ b/models/user.rb
@@ -17,6 +17,7 @@ class User
   has_many :comments, inverse_of: :author
   has_many :comment_threads, inverse_of: :author
   has_many :activities, class_name: "Notification", inverse_of: :actor
+  has_many :threads_closed, class_name: 'CommentThread', inverse_of: :closed_by
   has_and_belongs_to_many :notifications, inverse_of: :receivers
 
   validates_presence_of :external_id

--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -86,7 +86,7 @@ describe 'Comment API' do
     def test_update_endorsed(true_val, false_val)
       comment = thread.comments.first
       before = DateTime.now
-      put "/api/v1/comments/#{comment.id}", endorsed: true_val, endorsement_user_id: "#{User.first.id}"
+      put "/api/v1/comments/#{comment.id}", endorsed: true_val, endorsement_user_id: User.first.id
       after = DateTime.now
       last_response.should be_ok
       comment.reload
@@ -111,15 +111,21 @@ describe 'Comment API' do
 
     it 'updates body correctly' do
       comment = thread.comments.first
-      put "/api/v1/comments/#{comment.id}", body: 'new body'
+      original_body = comment.body
+      put "/api/v1/comments/#{comment.id}", body: 'new body', user_id: User.first.id, edit_reason_code: "test_reason"
       last_response.should be_ok
       comment.reload
-      comment.body.should == 'new body'
+      expect(comment.body).to eq 'new body'
+      edit_history = comment.edit_history.map(&:to_hash)
+      expect(edit_history.length).to eq 1
+      expect(edit_history[0]["original_body"]).to eq original_body
+      expect(edit_history[0]["reason_code"]).to eq "test_reason"
+      expect(edit_history[0]["editor_username"]).to eq User.first.id
     end
 
     it 'can update endorsed and body simultaneously' do
       comment = thread.comments.first
-      put "/api/v1/comments/#{comment.id}", body: 'new body', endorsed: true
+      put "/api/v1/comments/#{comment.id}", body: 'new body', endorsed: true, user_id: User.first.id
       last_response.should be_ok
       comment.reload
       comment.body.should == 'new body'
@@ -136,7 +142,7 @@ describe 'Comment API' do
       blocked_hash = block_post_body(BLOCKED_BODY)
       comment = thread.comments.first
       original_body = comment.body
-      put "/api/v1/comments/#{comment.id}", body: BLOCKED_BODY, endorsed: true
+      put "/api/v1/comments/#{comment.id}", body: BLOCKED_BODY, endorsed: true, user_id: User.first.id
       last_response.status.should == 503
       parse(last_response.body).first.should == I18n.t(:blocked_content_with_body_hash, :hash => blocked_hash)
       comment.reload
@@ -145,7 +151,7 @@ describe 'Comment API' do
 
     def test_unicode_data(text)
       comment = thread.comments.first
-      put "/api/v1/comments/#{comment.id}", body: text
+      put "/api/v1/comments/#{comment.id}", body: text, user_id: User.first.id
       last_response.should be_ok
       comment.reload
       comment.body.should == text

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = ".rspec-test-status"
 end
 
 Mongoid.configure do |config|
@@ -169,6 +170,7 @@ def check_thread_result(user, thread, hash, is_json=false)
   expected_keys += %w(anonymous anonymous_to_peers at_position_list closed user_id)
   expected_keys += %w(username votes abuse_flaggers tags type group_id pinned)
   expected_keys += %w(comments_count unread_comments_count read endorsed last_activity_at)
+  expected_keys += %w(closed_by edit_history)
   # these keys are checked separately, when desired, using check_thread_response_paging.
   actual_keys = hash.keys - [
     "children", "endorsed_responses", "non_endorsed_responses", "resp_skip",
@@ -184,6 +186,7 @@ def check_thread_result(user, thread, hash, is_json=false)
   expect(hash["commentable_id"]).to eq thread.commentable_id
   expect(hash["at_position_list"]).to eq thread.at_position_list
   expect(hash["closed"]).to eq thread.closed
+  expect(hash["closed_by"]).to eq thread.closed_by
   expect(hash["user_id"]).to eq thread.author.id
   expect(hash["username"]).to eq thread.author.username
   expect(hash["votes"]["point"]).to eq thread.votes["point"]
@@ -197,6 +200,14 @@ def check_thread_result(user, thread, hash, is_json=false)
   expect(hash["pinned"]).to eq thread.pinned?
   expect(hash["endorsed"]).to eq thread.endorsed?
   expect(hash["comments_count"]).to eq thread.comments.length
+  edit_history = thread.edit_history.map(&:to_hash).map do |item|
+    if is_json
+      item.merge("created_at"=>item["created_at"].utc.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    else
+      item.merge
+    end
+  end
+  expect(hash["edit_history"]).to eq edit_history
   hash["context"] = thread.context
 
   if is_json


### PR DESCRIPTION
Adds support for specifiying an optional edit reason when editing a post which is preserved when the post is edited by a user that isn't the original author (for instance a moderator). The edit reason can be used by the platform to indicate why a post or comment was changed, for instance if it contained answers. It also stores the user that made this change and retains the previous version of the body in this case.

It also adds support for a post close reason code. This can be specified when closing the post. The user closing a post is also tracked as closed_by.