### PR TITLE
Convert specs to RSpec 3.6.0 syntax with Transpec

### DIFF
--- a/spec/api/abuse_spec.rb
+++ b/spec/api/abuse_spec.rb
@@ -7,7 +7,7 @@ describe 'Abuse API' do
     let(:affected_entity_id) { affected_entity.id }
     let(:user_id) { create(:user).id }
 
-    it { should be_ok }
+    it { is_expected.to be_ok }
 
     it 'updates the abuse flaggers' do
       subject
@@ -19,13 +19,13 @@ describe 'Abuse API' do
 
     context 'if the comment does not exist' do
       let(:affected_entity_id) { 'does_not_exist' }
-      it { should be_bad_request }
+      it { is_expected.to be_bad_request }
       its(:body) { should eq "[\"#{I18n.t(:requested_object_not_found)}\"]" }
     end
 
     context 'if no user_id is provided' do
       let(:user_id) { nil }
-      it { should be_bad_request }
+      it { is_expected.to be_bad_request }
       its(:body) { should eq "[\"#{I18n.t(:user_id_is_required)}\"]" }
     end
   end

--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -11,38 +11,38 @@ describe 'Comment API' do
     it 'returns JSON' do
       comment = thread.comments.first
       get "/api/v1/comments/#{comment.id}"
-      last_response.should be_ok
-      last_response.content_type.should == 'application/json'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to eq('application/json')
     end
 
     it 'retrieves information of a single comment' do
       comment = thread.comments.first
       get "/api/v1/comments/#{comment.id}"
-      last_response.should be_ok
+      expect(last_response).to be_ok
       retrieved = parse last_response.body
-      retrieved['body'].should == comment.body
-      retrieved['endorsed'].should == comment.endorsed
-      retrieved['id'].should == comment.id.to_s
-      retrieved['children'].should be_nil
-      retrieved['votes']['point'].should == comment.votes_point
-      retrieved['depth'].should == comment.depth
-      retrieved['parent_id'].should == comment.parent_ids.map(&:to_s)[-1]
-      retrieved["child_count"].should == comment.children.length
+      expect(retrieved['body']).to eq(comment.body)
+      expect(retrieved['endorsed']).to eq(comment.endorsed)
+      expect(retrieved['id']).to eq(comment.id.to_s)
+      expect(retrieved['children']).to be_nil
+      expect(retrieved['votes']['point']).to eq(comment.votes_point)
+      expect(retrieved['depth']).to eq(comment.depth)
+      expect(retrieved['parent_id']).to eq(comment.parent_ids.map(&:to_s)[-1])
+      expect(retrieved["child_count"]).to eq(comment.children.length)
     end
 
     it 'retrieves information of a single comment with its sub comments' do
       comment = thread.comments.first
       get "/api/v1/comments/#{comment.id}", recursive: true
-      last_response.should be_ok
+      expect(last_response).to be_ok
       retrieved = parse last_response.body
-      retrieved['body'].should == comment.body
-      retrieved['endorsed'].should == comment.endorsed
-      retrieved['id'].should == comment.id.to_s
-      retrieved['votes']['point'].should == comment.votes_point
+      expect(retrieved['body']).to eq(comment.body)
+      expect(retrieved['endorsed']).to eq(comment.endorsed)
+      expect(retrieved['id']).to eq(comment.id.to_s)
+      expect(retrieved['votes']['point']).to eq(comment.votes_point)
 
       retrieved_children = retrieved['children']
-      retrieved_children.length.should == comment.children.length
-      retrieved["child_count"].should == comment.children.length
+      expect(retrieved_children.length).to eq(comment.children.length)
+      expect(retrieved["child_count"]).to eq(comment.children.length)
 
       comment.children.each_with_index do |child, index|
         expect(retrieved_children[index]).to include('body' => child.body, 'parent_id' => comment.id.to_s)
@@ -53,30 +53,30 @@ describe 'Comment API' do
       comment = thread.comments.first
       comment.set(child_count: 2000)
       comment_hash = comment.to_hash(recursive: true)
-      comment_hash["child_count"].should == 2000
+      expect(comment_hash["child_count"]).to eq(2000)
       get "/api/v1/comments/#{comment.id}", recursive: true
-      last_response.should be_ok
+      expect(last_response).to be_ok
       retrieved = parse last_response.body
-      retrieved["child_count"].should == comment.children.length
+      expect(retrieved["child_count"]).to eq(comment.children.length)
 
       comment.set(child_count: nil)
       get "/api/v1/comments/#{comment.id}"
-      last_response.should be_ok
+      expect(last_response).to be_ok
       retrieved = parse last_response.body
-      retrieved["child_count"].should == comment.children.length
+      expect(retrieved["child_count"]).to eq(comment.children.length)
     end
 
     it 'returns 400 when the comment does not exist' do
       get '/api/v1/comments/does_not_exist'
-      last_response.status.should == 400
-      parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+      expect(last_response.status).to eq(400)
+      expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
     end
 
     def test_unicode_data(text)
       comment = create(:comment, body: text)
       get "/api/v1/comments/#{comment.id}"
-      last_response.should be_ok
-      parse(last_response.body)['body'].should == text
+      expect(last_response).to be_ok
+      expect(parse(last_response.body)['body']).to eq(text)
     end
 
     include_examples 'unicode data'
@@ -88,17 +88,17 @@ describe 'Comment API' do
       before = DateTime.now
       put "/api/v1/comments/#{comment.id}", endorsed: true_val, endorsement_user_id: "#{User.first.id}"
       after = DateTime.now
-      last_response.should be_ok
+      expect(last_response).to be_ok
       comment.reload
-      comment.endorsed.should == true
-      comment.endorsement.should_not be_nil
-      comment.endorsement["user_id"].should == "#{User.first.id}"
-      comment.endorsement["time"].should be_between(before, after)
+      expect(comment.endorsed).to eq(true)
+      expect(comment.endorsement).not_to be_nil
+      expect(comment.endorsement["user_id"]).to eq("#{User.first.id}")
+      expect(comment.endorsement["time"]).to be_between(before, after)
       put "/api/v1/comments/#{comment.id}", endorsed: false_val
-      last_response.should be_ok
+      expect(last_response).to be_ok
       comment.reload
-      comment.endorsed.should == false
-      comment.endorsement.should be_nil
+      expect(comment.endorsed).to eq(false)
+      expect(comment.endorsement).to be_nil
     end
 
     it 'updates endorsed correctly' do
@@ -112,24 +112,24 @@ describe 'Comment API' do
     it 'updates body correctly' do
       comment = thread.comments.first
       put "/api/v1/comments/#{comment.id}", body: 'new body'
-      last_response.should be_ok
+      expect(last_response).to be_ok
       comment.reload
-      comment.body.should == 'new body'
+      expect(comment.body).to eq('new body')
     end
 
     it 'can update endorsed and body simultaneously' do
       comment = thread.comments.first
       put "/api/v1/comments/#{comment.id}", body: 'new body', endorsed: true
-      last_response.should be_ok
+      expect(last_response).to be_ok
       comment.reload
-      comment.body.should == 'new body'
-      comment.endorsed.should == true
+      expect(comment.body).to eq('new body')
+      expect(comment.endorsed).to eq(true)
     end
 
     it 'returns 400 when the comment does not exist' do
       put '/api/v1/comments/does_not_exist', body: 'new body', endorsed: true
-      last_response.status.should == 400
-      parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+      expect(last_response.status).to eq(400)
+      expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
     end
 
     it 'returns 503 and does not update when the post hash is blocked' do
@@ -137,18 +137,18 @@ describe 'Comment API' do
       comment = thread.comments.first
       original_body = comment.body
       put "/api/v1/comments/#{comment.id}", body: BLOCKED_BODY, endorsed: true
-      last_response.status.should == 503
-      parse(last_response.body).first.should == I18n.t(:blocked_content_with_body_hash, :hash => blocked_hash)
+      expect(last_response.status).to eq(503)
+      expect(parse(last_response.body).first).to eq(I18n.t(:blocked_content_with_body_hash, :hash => blocked_hash))
       comment.reload
-      comment.body.should == original_body
+      expect(comment.body).to eq(original_body)
     end
 
     def test_unicode_data(text)
       comment = thread.comments.first
       put "/api/v1/comments/#{comment.id}", body: text
-      last_response.should be_ok
+      expect(last_response).to be_ok
       comment.reload
-      comment.body.should == text
+      expect(comment.body).to eq(text)
     end
 
     include_examples 'unicode data'
@@ -162,24 +162,24 @@ describe 'Comment API' do
       body = 'new comment'
       course_id = '1'
       post "/api/v1/comments/#{comment.id}", body: body, course_id: course_id, user_id: user.id
-      last_response.should be_ok
+      expect(last_response).to be_ok
 
       comment.reload
-      comment.children.length.should == previous_child_count + 1
-      comment.child_count.should == previous_child_count + 1
+      expect(comment.children.length).to eq(previous_child_count + 1)
+      expect(comment.child_count).to eq(previous_child_count + 1)
       sub_comment = comment.children.order_by(created_at: :desc).first
-      sub_comment.body.should == body
-      sub_comment.course_id.should == course_id
-      sub_comment.author.should == user
-      sub_comment.child_count.should == 0
+      expect(sub_comment.body).to eq(body)
+      expect(sub_comment.course_id).to eq(course_id)
+      expect(sub_comment.author).to eq(user)
+      expect(sub_comment.child_count).to eq(0)
 
       test_thread_marked_as_read(thread.id, user.id)
     end
 
     it 'returns 400 when the comment does not exist' do
       post '/api/v1/comments/does_not_exist', body: 'new comment', course_id: '1', user_id: thread.author.id
-      last_response.status.should == 400
-      parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+      expect(last_response.status).to eq(400)
+      expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
     end
 
     it 'returns 503 and does not create when the post hash is blocked' do
@@ -187,16 +187,16 @@ describe 'Comment API' do
       comment = thread.comments.first
       user = comment.author
       post "/api/v1/comments/#{comment.id}", body: BLOCKED_BODY, course_id: '1', user_id: user.id
-      last_response.status.should == 503
-      parse(last_response.body).first.should == I18n.t(:blocked_content_with_body_hash, :hash => blocked_hash)
-      Comment.where(body: BLOCKED_BODY).to_a.should be_empty
+      expect(last_response.status).to eq(503)
+      expect(parse(last_response.body).first).to eq(I18n.t(:blocked_content_with_body_hash, :hash => blocked_hash))
+      expect(Comment.where(body: BLOCKED_BODY).to_a).to be_empty
     end
 
     def test_unicode_data(text)
       parent = thread.comments.first
       post "/api/v1/comments/#{parent.id}", body: text, course_id: parent.course_id, user_id: User.first.id
-      last_response.should be_ok
-      parent.children.where(body: text).should_not be_empty
+      expect(last_response).to be_ok
+      expect(parent.children.where(body: text)).not_to be_empty
     end
 
     include_examples 'unicode data'
@@ -208,8 +208,8 @@ describe 'Comment API' do
       cnt_comments = comment.descendants_and_self.length
       prev_count = Comment.count
       delete "/api/v1/comments/#{comment.id}"
-      Comment.count.should == prev_count - cnt_comments
-      Comment.all.select { |c| c.id == comment.id }.first.should be_nil
+      expect(Comment.count).to eq(prev_count - cnt_comments)
+      expect(Comment.all.select { |c| c.id == comment.id }.first).to be_nil
     end
 
     it 'can delete a sub comment' do
@@ -218,14 +218,14 @@ describe 'Comment API' do
       child_comment = parent_comment.children.first
       delete "/api/v1/comments/#{child_comment.id}"
 
-      Comment.where(:id => child_comment.id).should be_empty
-      parent_comment.children.where(:id => child_comment.id).should be_empty
+      expect(Comment.where(:id => child_comment.id)).to be_empty
+      expect(parent_comment.children.where(:id => child_comment.id)).to be_empty
     end
 
     it 'returns 400 when the comment does not exist' do
       delete '/api/v1/comments/does_not_exist'
-      last_response.status.should == 400
-      parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+      expect(last_response.status).to eq(400)
+      expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
     end
   end
 end

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -12,7 +12,7 @@ describe 'app' do
 
       def thread_result(params)
         get "/api/v1/threads", params
-        last_response.should be_ok
+        expect(last_response).to be_ok
         parse(last_response.body)["collection"]
       end
 
@@ -23,10 +23,10 @@ describe 'app' do
             t.save!
           end
           rs = thread_result course_id: "abc"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           rs.each_with_index { |res, i|
             check_thread_result_json(nil, @threads["t#{2-i}"], res)
-            res["course_id"].should == "abc"
+            expect(res["course_id"]).to eq("abc")
           }
         end
         it "does not return standalone threads" do
@@ -37,7 +37,7 @@ describe 'app' do
           @threads["t2"].context = :standalone
           @threads["t2"].save!
           rs = thread_result course_id: "abc"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           check_thread_result_json(nil, @threads["t3"], rs[0])
           check_thread_result_json(nil, @threads["t1"], rs[1])
         end
@@ -55,7 +55,7 @@ describe 'app' do
           @threads["t4"].commentable_id = "commentable1"
           @threads["t4"].save!
           rs = thread_result course_id: "course1", commentable_ids: "commentable1,commentable3"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           check_thread_result_json(nil, @threads["t3"], rs[0])
           check_thread_result_json(nil, @threads["t1"], rs[1])
         end
@@ -67,7 +67,7 @@ describe 'app' do
           @threads["t2"].group_id = 101
           @threads["t2"].save!
           rs = thread_result course_id: "omg", group_id: 100
-          rs.length.should == 1
+          expect(rs.length).to eq(1)
           check_thread_result_json(nil, @threads["t1"], rs.first)
         end
         it "returns only threads where course id and group ids match" do
@@ -78,7 +78,7 @@ describe 'app' do
           @threads["t2"].group_id = 101
           @threads["t2"].save!
           rs = thread_result course_id: "omg", group_ids: "100,101"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
         end
         it "returns only threads where course id and group id match or group id is nil" do
           @threads["t1"].course_id = "omg"
@@ -89,40 +89,40 @@ describe 'app' do
           @threads["t3"].group_id = 100
           @threads["t3"].save!
           rs = thread_result course_id: "omg", group_id: 100
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           rs.each_with_index { |res, i|
             check_thread_result_json(nil, @threads["t#{2-i}"], res)
-            res["course_id"].should == "omg"
+            expect(res["course_id"]).to eq("omg")
           }
         end
         it "returns an empty result when no threads match course_id" do
           rs = thread_result course_id: 99
-          rs.length.should == 0
+          expect(rs.length).to eq(0)
         end
         it "returns only group-less threads when no threads have matching group id" do
           @threads["t1"].group_id = 123
           @threads["t1"].save!
           rs = thread_result course_id: DFLT_COURSE_ID, group_id: 321
-          rs.each.map { |res| res["group_id"].should be_nil }
+          rs.each.map { |res| expect(res["group_id"]).to be_nil }
         end
         context "when filtering flagged posts" do
           it "returns threads that are flagged" do
             @threads["t1"].abuse_flaggers = [1]
             @threads["t1"].save!
             rs = thread_result course_id: DFLT_COURSE_ID, flagged: true
-            rs.length.should == 1
+            expect(rs.length).to eq(1)
             check_thread_result_json(nil, @threads["t1"], rs.first)
           end
           it "returns threads that have flagged comments" do
             @comments["t2 c3"].abuse_flaggers = [1]
             @comments["t2 c3"].save!
             rs = thread_result course_id: DFLT_COURSE_ID, flagged: true
-            rs.length.should == 1
+            expect(rs.length).to eq(1)
             check_thread_result_json(nil, @threads["t2"], rs.first)
           end
           it "returns an empty result when no posts were flagged" do
             rs = thread_result course_id: DFLT_COURSE_ID, flagged: true
-            rs.length.should == 0
+            expect(rs.length).to eq(0)
           end
         end
         context "when filtering posts by author" do
@@ -178,28 +178,28 @@ describe 'app' do
           end
           it "returns all threads when thread_type is not provided" do
             rs = thread_result course_id: DFLT_COURSE_ID
-            rs.length.should == 10
+            expect(rs.length).to eq(10)
           end
         end
         it "filters unread posts" do
           user = create_test_user(Random.new)
           rs = thread_result course_id: DFLT_COURSE_ID, user_id: user.id
-          rs.length.should == 10
+          expect(rs.length).to eq(10)
           rs2 = thread_result course_id: DFLT_COURSE_ID, user_id: user.id, unread: true
-          rs2.should == rs
+          expect(rs2).to eq(rs)
           user.mark_as_read(@threads[rs.first["title"]])
           rs3 = thread_result course_id: DFLT_COURSE_ID, user_id: user.id, unread: true
-          rs3.should == rs[1..9]
+          expect(rs3).to eq(rs[1..9])
           rs[1..8].each { |r| user.mark_as_read(@threads[r["title"]]) }
           rs4 = thread_result course_id: DFLT_COURSE_ID, user_id: user.id, unread: true
-          rs4.should == rs[9, 1]
+          expect(rs4).to eq(rs[9, 1])
           user.mark_as_read(@threads[rs.last["title"]])
           rs5 = thread_result course_id: DFLT_COURSE_ID, user_id: user.id, unread: true
-          rs5.should == []
+          expect(rs5).to eq([])
           make_comment(create_test_user(Random.new), @threads[rs.first["title"]], "new activity")
           rs6 = thread_result course_id: DFLT_COURSE_ID, user_id: user.id, unread: true
-          rs6.length.should == 1
-          rs6.first["title"].should == rs.first["title"]
+          expect(rs6.length).to eq(1)
+          expect(rs6.first["title"]).to eq(rs.first["title"])
         end
         it "filters unanswered questions" do
           %w[t9 t7 t5 t3 t1].each do |thread_key|
@@ -207,22 +207,22 @@ describe 'app' do
             @threads[thread_key].save!
           end
           rs = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-          rs.length.should == 5
+          expect(rs.length).to eq(5)
           @comments["t1 c0"].endorsed = true
           @comments["t1 c0"].save!
           rs2 = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-          rs2.length.should == 4
+          expect(rs2.length).to eq(4)
           %w[t9 t7 t5].each do |thread_key|
             comment = @threads[thread_key].comments.first
             comment.endorsed = true
             comment.save!
           end
           rs3 = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-          rs3.length.should == 1
+          expect(rs3.length).to eq(1)
           @comments["t3 c0"].endorsed = true
           @comments["t3 c0"].save!
           rs3 = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-          rs3.length.should == 0
+          expect(rs3.length).to eq(0)
         end
         it "ignores endorsed comments that are not question responses" do
           thread = @threads["t0"]
@@ -232,7 +232,7 @@ describe 'app' do
           comment.endorsed = true
           comment.save!
           rs = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-          rs.length.should == 1
+          expect(rs.length).to eq(1)
         end
         it "correctly considers read state" do
           user = create_test_user(123)
@@ -241,52 +241,52 @@ describe 'app' do
             t.save!
           end
           rs = thread_result course_id: "abc", user_id: "123"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           rs.each_with_index { |result, i|
             check_thread_result_json(user, @threads["t#{2-i}"], result)
-            result["course_id"].should == "abc"
-            result["unread_comments_count"].should == 5
-            result["read"].should == false
+            expect(result["course_id"]).to eq("abc")
+            expect(result["unread_comments_count"]).to eq(5)
+            expect(result["read"]).to eq(false)
           }
 
           user.mark_as_read(@threads["t1"])
           rs = thread_result course_id: "abc", user_id: "123"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           rs.each_with_index { |result, i|
             check_thread_result_json(user, @threads["t#{2-i}"], result)
           }
-          rs[1]["read"].should == true
-          rs[1]["unread_comments_count"].should == 0
-          rs[0]["read"].should == false
-          rs[0]["unread_comments_count"].should == 5
+          expect(rs[1]["read"]).to eq(true)
+          expect(rs[1]["unread_comments_count"]).to eq(0)
+          expect(rs[0]["read"]).to eq(false)
+          expect(rs[0]["unread_comments_count"]).to eq(5)
 
           @threads["t1"].updated_at += 1 # 1 second later
           @threads["t1"].save!
           rs = thread_result course_id: "abc", user_id: "123"
-          rs.length.should == 2
+          expect(rs.length).to eq(2)
           rs.each_with_index { |result, i|
             check_thread_result_json(user, @threads["t#{2-i}"], result)
           }
-          rs[1]["read"].should == true
-          rs[1]["unread_comments_count"].should == 0
-          rs[0]["read"].should == false
-          rs[0]["unread_comments_count"].should == 5
+          expect(rs[1]["read"]).to eq(true)
+          expect(rs[1]["unread_comments_count"]).to eq(0)
+          expect(rs[0]["read"]).to eq(false)
+          expect(rs[0]["unread_comments_count"]).to eq(5)
 
           # author's own posts should not count as unread
           make_comment(user, @threads["t1"], "my two cents")
           rs = thread_result course_id: "abc", user_id: "123"
-          rs[1]["unread_comments_count"].should == 0
+          expect(rs[1]["unread_comments_count"]).to eq(0)
 
           # other's posts do, though
           make_comment(@threads["t1"].author, @threads["t1"], "the last word")
           rs = thread_result course_id: "abc", user_id: "123"
-          rs[1]["unread_comments_count"].should == 1
+          expect(rs[1]["unread_comments_count"]).to eq(1)
         end
 
         context "sorting" do
           def thread_result_order (sort_key)
             results = thread_result course_id: DFLT_COURSE_ID, sort_key: sort_key
-            results.length.should == 10
+            expect(results.length).to eq(10)
             results.map { |t| t["title"] }
           end
 
@@ -307,7 +307,7 @@ describe 'app' do
           it "sorts using create date / descending" do
             actual_order = thread_result_order("date")
             expected_order = @default_order
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
           it "sort unchanged using last activity / descending when thread is updated" do
             t5 = @threads["t5"]
@@ -315,7 +315,7 @@ describe 'app' do
             t5.save!
             actual_order = thread_result_order("activity")
             expected_order = @default_order
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
           it "sort unchanged using last activity / descending when comment is updated" do
             t5c = @threads["t5"].comments.first
@@ -323,7 +323,7 @@ describe 'app' do
             t5c.save!
             actual_order = thread_result_order("activity")
             expected_order = @default_order
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
           it "sorts using last activity / descending when response is created" do
             t5 = @threads["t5"]
@@ -333,7 +333,7 @@ describe 'app' do
 
             actual_order = thread_result_order("activity")
             expected_order = move_to_front(@default_order, "t5")
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
           it "sorts using vote count / descending" do
             user = User.all.first
@@ -342,13 +342,13 @@ describe 'app' do
             t5.save!
             actual_order = thread_result_order("votes")
             expected_order = move_to_front(@default_order, "t5")
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
           it "sorts using comment count / descending" do
             make_comment(@threads["t5"].author, @threads["t5"], "extra comment")
             actual_order = thread_result_order("comments")
             expected_order = move_to_front(@default_order, "t5")
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
           it "sorts pinned items first" do
             make_comment(@threads["t5"].author, @threads["t5"], "extra comment")
@@ -357,60 +357,60 @@ describe 'app' do
 
             actual_order = thread_result_order("comments")
             expected_order = move_to_front(@default_order, "t7", "t5")
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
 
             @threads["t8"].pinned = true
             @threads["t8"].save!
 
             actual_order = thread_result_order("comments")
             expected_order = move_to_front(@default_order, "t8", "t7", "t5")
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
 
             actual_order = thread_result_order("date")
             expected_order = move_to_front(@default_order, "t8", "t7")
-            actual_order.should == expected_order
+            expect(actual_order).to eq(expected_order)
           end
 
           context "pagination" do
             def thread_result_page (sort_key, page, per_page, course_id=DFLT_COURSE_ID, user_id=nil, unread=false)
               get "/api/v1/threads", course_id: course_id, sort_key: sort_key, page: page, per_page: per_page, user_id: user_id, unread: unread
-              last_response.should be_ok
+              expect(last_response).to be_ok
               parse(last_response.body)
             end
             it "returns single page with no threads in a course" do
               result = thread_result_page("date", 1, 20, "99")
-              result["collection"].length.should == 0
-              result["thread_count"].should == 0
-              result["num_pages"].should == 1
-              result["page"].should == 1
+              expect(result["collection"].length).to eq(0)
+              expect(result["thread_count"]).to eq(0)
+              expect(result["num_pages"]).to eq(1)
+              expect(result["page"]).to eq(1)
             end
             it "returns single page" do
               result = thread_result_page("date", 1, 20)
-              result["collection"].length.should == 10
-              result["thread_count"].should == 10
-              result["num_pages"].should == 1
-              result["page"].should == 1
+              expect(result["collection"].length).to eq(10)
+              expect(result["thread_count"]).to eq(10)
+              expect(result["num_pages"]).to eq(1)
+              expect(result["page"]).to eq(1)
             end
             it "returns multiple pages" do
               result = thread_result_page("date", 1, 5)
-              result["collection"].length.should == 5
-              result["thread_count"].should == 10
-              result["num_pages"].should == 2
-              result["page"].should == 1
+              expect(result["collection"].length).to eq(5)
+              expect(result["thread_count"]).to eq(10)
+              expect(result["num_pages"]).to eq(2)
+              expect(result["page"]).to eq(1)
 
               result = thread_result_page("date", 2, 5)
-              result["collection"].length.should == 5
-              result["thread_count"].should == 10
-              result["num_pages"].should == 2
-              result["page"].should == 2
+              expect(result["collection"].length).to eq(5)
+              expect(result["thread_count"]).to eq(10)
+              expect(result["num_pages"]).to eq(2)
+              expect(result["page"]).to eq(2)
             end
             it "returns page exceeding available pages with no results" do
               #TODO: Review whether we can switch pagination endpoint to raise an exception; rather than an empty page
               result = thread_result_page("date", 3, 5)
-              result["collection"].length.should == 0
-              result["thread_count"].should == 10
-              result["num_pages"].should == 2
-              result["page"].should == 3
+              expect(result["collection"].length).to eq(0)
+              expect(result["thread_count"]).to eq(10)
+              expect(result["num_pages"]).to eq(2)
+              expect(result["page"]).to eq(3)
             end
 
             def test_paged_order (sort_spec, expected_order, filter_spec=[], user_id=nil)
@@ -430,17 +430,17 @@ describe 'app' do
                     user_id,
                     filter_spec.include?("unread")
                 )
-                result["collection"].length.should == (page * per_page <= expected_order.length ? per_page : expected_order.length % per_page)
+                expect(result["collection"].length).to eq(page * per_page <= expected_order.length ? per_page : expected_order.length % per_page)
                 if filter_spec.include?("unread")
                   # because of the way we handle num_pages for the unread filter, this is a special case.
-                  result["num_pages"].should == (page == num_pages ? page : page + 1)
+                  expect(result["num_pages"]).to eq(page == num_pages ? page : page + 1)
                 else
-                  result["num_pages"].should == num_pages
+                  expect(result["num_pages"]).to eq(num_pages)
                 end
-                result["page"].should == page
+                expect(result["page"]).to eq(page)
                 actual_order += result["collection"].map { |v| v["title"] }
               end
-              actual_order.should == expected_order
+              expect(actual_order).to eq(expected_order)
             end
 
             it "orders correctly across pages" do
@@ -492,7 +492,7 @@ describe 'app' do
         get "/api/v1/threads/#{thread.id}"
       end
 
-      it { should be_ok }
+      it { is_expected.to be_ok }
 
       it 'returns JSON' do
         expect(subject.content_type).to eq 'application/json'
@@ -531,7 +531,7 @@ describe 'app' do
           get "/api/v1/threads/#{thread.id}", {:user_id => thread.author.id, :mark_as_read => true}
         end
 
-        it { should be_ok }
+        it { is_expected.to be_ok }
 
         # This is a test to ensure that the username is included even if the
         # thread's author is the one looking at the comment. This is because of a
@@ -550,7 +550,7 @@ describe 'app' do
           get "/api/v1/threads/#{thread.id}", recursive: true
         end
 
-        it { should be_ok }
+        it { is_expected.to be_ok }
 
         it 'get information of a single comment thread with its comments' do
           parsed = parse(subject.body)
@@ -574,7 +574,7 @@ describe 'app' do
           last_response
         end
 
-        it { should be_ok }
+        it { is_expected.to be_ok }
 
         it 'marks thread as read and confirms its value on returned response' do
           parsed = parse(subject.body)
@@ -635,7 +635,7 @@ describe 'app' do
 
         def thread_result(id, params)
           get "/api/v1/threads/#{id}", params
-          last_response.should be_ok
+          expect(last_response).to be_ok
           parse(last_response.body)
         end
 
@@ -680,42 +680,42 @@ describe 'app' do
         comment.endorsed = true
         comment.save
         put "/api/v1/threads/#{thread.id}", body: "new body", title: "new title", commentable_id: "new_commentable_id", thread_type: "question"
-        last_response.should be_ok
+        expect(last_response).to be_ok
         changed_thread = CommentThread.find(thread.id)
-        changed_thread.body.should == "new body"
-        changed_thread.title.should == "new title"
-        changed_thread.commentable_id.should == "new_commentable_id"
-        changed_thread.thread_type.should == "question"
+        expect(changed_thread.body).to eq("new body")
+        expect(changed_thread.title).to eq("new title")
+        expect(changed_thread.commentable_id).to eq("new_commentable_id")
+        expect(changed_thread.thread_type).to eq("question")
         comment.reload
-        comment.endorsed.should == false
-        comment.endorsement.should == nil
+        expect(comment.endorsed).to eq(false)
+        expect(comment.endorsement).to eq(nil)
         check_unread_thread_result_json(changed_thread, parse(last_response.body))
       end
       it "returns 400 when the thread does not exist" do
         put "/api/v1/threads/does_not_exist", body: "new body", title: "new title"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
       end
       it "returns 503 and does not update if the post body has been blocked" do
         thread = CommentThread.first
         original_body = thread.body
         put "/api/v1/threads/#{thread.id}", body: "BLOCKED POST", title: "new title", commentable_id: "new_commentable_id"
-        last_response.status.should == 503
+        expect(last_response.status).to eq(503)
         thread.reload
-        thread.body.should == original_body
+        expect(thread.body).to eq(original_body)
         put "/api/v1/threads/#{thread.id}", body: "blocked,   post...", title: "new title", commentable_id: "new_commentable_id"
-        last_response.status.should == 503
+        expect(last_response.status).to eq(503)
         thread.reload
-        thread.body.should == original_body
+        expect(thread.body).to eq(original_body)
       end
 
       def test_unicode_data(text)
         thread = CommentThread.first
         put "/api/v1/threads/#{thread.id}", body: text, title: text
-        last_response.should be_ok
+        expect(last_response).to be_ok
         thread = CommentThread.find(thread.id)
-        thread.body.should == text
-        thread.title.should == text
+        expect(thread.body).to eq(text)
+        expect(thread.title).to eq(text)
       end
 
       include_examples "unicode data"
@@ -732,14 +732,14 @@ describe 'app' do
         user = User.first
         orig_count = thread.comment_count
         post "/api/v1/threads/#{thread.id}/comments", default_params
-        last_response.should be_ok
+        expect(last_response).to be_ok
         retrieved = parse last_response.body
         changed_thread = CommentThread.find(thread.id)
-        changed_thread.comment_count.should == orig_count + 1
+        expect(changed_thread.comment_count).to eq(orig_count + 1)
         comment = changed_thread.comments.select { |c| c["body"] == "new comment" }.first
-        comment.should_not be_nil
-        comment.author_id.should == user.id
-        retrieved["child_count"].should == 0
+        expect(comment).not_to be_nil
+        expect(comment.author_id).to eq(user.id)
+        expect(retrieved["child_count"]).to eq(0)
 
         test_thread_marked_as_read(thread.id, user.id)
       end
@@ -748,37 +748,37 @@ describe 'app' do
         user = User.first
         orig_count = thread.comment_count
         post "/api/v1/threads/#{thread.id}/comments", default_params.merge(anonymous: true)
-        last_response.should be_ok
+        expect(last_response).to be_ok
         changed_thread = CommentThread.find(thread.id)
-        changed_thread.comment_count.should == orig_count + 1
+        expect(changed_thread.comment_count).to eq(orig_count + 1)
         comment = changed_thread.comments.select { |c| c["body"] == "new comment" }.first
-        comment.should_not be_nil
-        comment.anonymous.should be true
+        expect(comment).not_to be_nil
+        expect(comment.anonymous).to be true
       end
       it "returns 400 when the thread does not exist" do
         post "/api/v1/threads/does_not_exist/comments", default_params
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
       end
       it "returns error when body or course_id does not exist, or when body is blank" do
         post "/api/v1/threads/#{CommentThread.first.id}/comments", default_params.merge(body: nil)
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
         post "/api/v1/threads/#{CommentThread.first.id}/comments", default_params.merge(course_id: nil)
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
         post "/api/v1/threads/#{CommentThread.first.id}/comments", default_params.merge(body: "    \n      \n  ")
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
       end
       it "returns 503 and does not create when the post body has been blocked" do
         post "/api/v1/threads/#{CommentThread.first.id}/comments", default_params.merge(body: "BLOCKED POST")
-        last_response.status.should == 503
-        Comment.where(body: "BLOCKED POST").to_a.should be_empty
+        expect(last_response.status).to eq(503)
+        expect(Comment.where(body: "BLOCKED POST").to_a).to be_empty
       end
 
       def test_unicode_data(text)
         thread = CommentThread.first
         post "/api/v1/threads/#{thread.id}/comments", default_params.merge(body: text)
-        last_response.should be_ok
-        thread.comments.where(body: text).should_not be_empty
+        expect(last_response).to be_ok
+        expect(thread.comments.where(body: text)).not_to be_empty
       end
 
       include_examples "unicode data"
@@ -789,7 +789,7 @@ describe 'app' do
 
       subject { delete "/api/v1/threads/#{thread.id}" }
 
-      it { should be_ok }
+      it { is_expected.to be_ok }
 
       it 'deletes the comment thread and its comments' do
         expect(CommentThread.where(id: thread.id).count).to eq 1

--- a/spec/api/commentable_spec.rb
+++ b/spec/api/commentable_spec.rb
@@ -42,7 +42,7 @@ describe 'app' do
       context 'if the commentable does not exist' do
         subject { delete '/api/v1/does_not_exist/threads' }
 
-        it { should be_ok }
+        it { is_expected.to be_ok }
       end
     end
 
@@ -54,7 +54,7 @@ describe 'app' do
         let!(:ignored_threads) { create_list(:comment_thread, 3, commentable_id: commentable_id) }
         subject { get "/api/v1/#{commentable_id}/threads", parameters }
 
-        it { should be_ok }
+        it { is_expected.to be_ok }
 
         it 'returns the correct CommentThreads' do
           expect(returned_threads.length).to eq threads.length
@@ -118,7 +118,7 @@ describe 'app' do
       context 'when the commentable does not exist' do
         subject { get '/api/v1/does_not_exist/threads' }
 
-        it { should be_ok }
+        it { is_expected.to be_ok }
 
         it 'should not return any results' do
           expect(returned_threads.length).to eq 0
@@ -164,7 +164,7 @@ describe 'app' do
         end
       end
 
-      it { should be_ok }
+      it { is_expected.to be_ok }
 
       it_behaves_like 'CommentThread creation API'
       it_behaves_like 'CommentThread creation API', 'standalone' do

--- a/spec/api/i18n_spec.rb
+++ b/spec/api/i18n_spec.rb
@@ -6,7 +6,7 @@ describe 'i18n' do
 
   it 'should respect the Accept-Language header' do
     put '/api/v1/comments/does_not_exist/votes', {}, {'HTTP_ACCEPT_LANGUAGE' => 'x-test'}
-    last_response.status.should == 400
-    parse(last_response.body).first.should == '##x-test## requested object not found'
+    expect(last_response.status).to eq(400)
+    expect(parse(last_response.body).first).to eq('##x-test## requested object not found')
   end
 end

--- a/spec/api/notifications_and_subscriptions_spec.rb
+++ b/spec/api/notifications_and_subscriptions_spec.rb
@@ -15,7 +15,7 @@ describe "app" do
 
       def thread_result(params)
         get "/api/v1/users/#{subscriber.id}/subscribed_threads", params
-        last_response.should be_ok
+        expect(last_response).to be_ok
         parse(last_response.body)["collection"]
       end
 
@@ -24,7 +24,7 @@ describe "app" do
           @threads["t1"].abuse_flaggers = [1]
           @threads["t1"].save!
           rs = thread_result course_id: DFLT_COURSE_ID, flagged: true
-          rs.length.should == 1
+          expect(rs.length).to eq(1)
           check_thread_result_json(nil, @threads["t1"], rs.first)
         end
         it "returns threads that have flagged comments" do
@@ -33,54 +33,54 @@ describe "app" do
           @comments["t3 c3"].abuse_flaggers = [1] # subscribed
           @comments["t3 c3"].save!
           rs = thread_result course_id: DFLT_COURSE_ID, flagged: true
-          rs.length.should == 1
+          expect(rs.length).to eq(1)
           check_thread_result_json(nil, @threads["t3"], rs.first)
         end
         it "returns an empty result when no posts were flagged" do
           rs = thread_result course_id: DFLT_COURSE_ID, flagged: true
-          rs.length.should == 0 
+          expect(rs.length).to eq(0) 
         end
       end
       it "filters by group_id" do
         rs = thread_result course_id: DFLT_COURSE_ID, group_id: 42
-        rs.length.should == 5
+        expect(rs.length).to eq(5)
         @threads["t3"].group_id = 43
         @threads["t3"].save!
         rs = thread_result course_id: DFLT_COURSE_ID, group_id: 42
-        rs.length.should == 4
+        expect(rs.length).to eq(4)
         @threads["t3"].group_id = 42
         @threads["t3"].save!
         rs = thread_result course_id: DFLT_COURSE_ID, group_id: 42
-        rs.length.should == 5
+        expect(rs.length).to eq(5)
       end
       it "filters by group_ids" do
         rs = thread_result course_id: DFLT_COURSE_ID, group_ids: "42"
-        rs.length.should == 5
+        expect(rs.length).to eq(5)
         @threads["t3"].group_id = 43
         @threads["t3"].save!
         rs = thread_result course_id: DFLT_COURSE_ID, group_ids: "42"
-        rs.length.should == 4
+        expect(rs.length).to eq(4)
         rs = thread_result course_id: DFLT_COURSE_ID, group_ids: "42,43"
-        rs.length.should == 5
+        expect(rs.length).to eq(5)
       end
       it "filters unread posts" do
         rs = thread_result course_id: DFLT_COURSE_ID
-        rs.length.should == 5
+        expect(rs.length).to eq(5)
         rs2 = thread_result course_id: DFLT_COURSE_ID, unread: true
-        rs2.should == rs
+        expect(rs2).to eq(rs)
         subscriber.mark_as_read(@threads[rs.first["title"]])
         rs3 = thread_result course_id: DFLT_COURSE_ID, unread: true
-        rs3.should == rs[1..4]
+        expect(rs3).to eq(rs[1..4])
         rs[1..3].each { |r| subscriber.mark_as_read(@threads[r["title"]]) }
         rs4 = thread_result course_id: DFLT_COURSE_ID, unread: true
-        rs4.should == rs[4, 1]
+        expect(rs4).to eq(rs[4, 1])
         subscriber.mark_as_read(@threads[rs.last["title"]])
         rs5 = thread_result course_id: DFLT_COURSE_ID, unread: true
-        rs5.should == []
+        expect(rs5).to eq([])
         make_comment(create_test_user(Random.new), @threads[rs.first["title"]], "new activity")
         rs6 = thread_result course_id: DFLT_COURSE_ID, unread: true
-        rs6.length.should == 1
-        rs6.first["title"].should == rs.first["title"]
+        expect(rs6.length).to eq(1)
+        expect(rs6.first["title"]).to eq(rs.first["title"])
       end
       it "filters unanswered questions" do
         %w[t9 t7].each do |thread_key|
@@ -88,27 +88,27 @@ describe "app" do
           @threads[thread_key].save!
         end
         rs = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-        rs.length.should == 2
+        expect(rs.length).to eq(2)
         @comments["t7 c0"].endorsed = true
         @comments["t7 c0"].save!
         rs2 = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-        rs2.length.should == 1
+        expect(rs2.length).to eq(1)
         @comments["t9 c0"].endorsed = true
         @comments["t9 c0"].save!
         rs3 = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-        rs3.length.should == 0
+        expect(rs3.length).to eq(0)
       end
       it "ignores endorsed comments that are not question responses" do
         thread = @threads["t1"]
         thread.thread_type = :question
         thread.save!
         rs = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-        rs.length.should == 1
+        expect(rs.length).to eq(1)
         comment = make_comment(create_test_user(Random.new), thread.comments.first, "comment on a response")
         comment.endorsed = true
         comment.save!
         rs2 = thread_result course_id: DFLT_COURSE_ID, unanswered: true
-        rs2.length.should == 1
+        expect(rs2.length).to eq(1)
       end
     end
 
@@ -116,9 +116,9 @@ describe "app" do
       it "subscribe a comment thread" do
         thread = @threads["t0"]
         post "/api/v1/users/#{subscriber.external_id}/subscriptions", source_type: "thread", source_id: thread.id
-        last_response.should be_ok
-        thread.subscribers.length.should == 1
-        thread.subscribers[0].should == subscriber
+        expect(last_response).to be_ok
+        expect(thread.subscribers.length).to eq(1)
+        expect(thread.subscribers[0]).to eq(subscriber)
       end
     end
 
@@ -126,11 +126,11 @@ describe "app" do
       it "unsubscribe a comment thread" do
         thread = @threads["t2"]
         subscriber.subscribe(thread)
-        thread.subscribers.length.should == 1
-        thread.subscribers[0].should == subscriber
+        expect(thread.subscribers.length).to eq(1)
+        expect(thread.subscribers[0]).to eq(subscriber)
         delete "/api/v1/users/#{subscriber.external_id}/subscriptions", source_type: "thread", source_id: thread.id
-        last_response.should be_ok
-        thread.subscribers.length.should == 0
+        expect(last_response).to be_ok
+        expect(thread.subscribers.length).to eq(0)
       end
     end
 

--- a/spec/api/notifications_spec.rb
+++ b/spec/api/notifications_spec.rb
@@ -62,7 +62,7 @@ describe "app" do
         }
       )
 
-      last_response.should be_ok
+      expect(last_response).to be_ok
       response_hash = JSON.parse(last_response.body)
       return response_hash[user.id][comment.course_id][thread.id.to_s]
     end
@@ -72,17 +72,17 @@ describe "app" do
         expected_comment_body = random_string = (0..5).map{ ('a'..'z').to_a[rand(26)] }.join
         thread_notification = get_thread_notification(expected_comment_body)
         actual_comment_body = thread_notification["content"][0]["body"]
-        actual_comment_body.should eq(expected_comment_body)
+        expect(actual_comment_body).to eq(expected_comment_body)
       end
 
       it "contains cohort group_id if defined" do
         thread_notification = get_thread_notification("dummy comment content", :group_id => 1974)
-        thread_notification["group_id"].should be(1974)
+        expect(thread_notification["group_id"]).to be(1974)
       end
 
       it "does not contain cohort group_id if not defined" do
         thread_notification = get_thread_notification("dummy comment content")
-        thread_notification.has_key?("group_id").should be false
+        expect(thread_notification.has_key?("group_id")).to be false
       end
 
       it "returns only threads subscribed to by user" do
@@ -108,7 +108,7 @@ describe "app" do
 
         post "/api/v1/notifications", from: CGI::escape(start_time.to_s), to: CGI::escape(end_time.to_s), user_ids: user.id
 
-        last_response.should be_ok
+        expect(last_response).to be_ok
         payload = JSON.parse last_response.body
         courses = payload[user.id.to_s]
         thread_ids = []
@@ -121,7 +121,7 @@ describe "app" do
         subscriptions = Subscription.where(:subscriber_id => user.id.to_s)
         subscribed_thread_ids = subscriptions.collect{|s| s.source_id}
 
-        (subscribed_thread_ids.to_set.superset? thread_ids.to_set).should == true
+        expect(subscribed_thread_ids.to_set.superset? thread_ids.to_set).to eq(true)
 
       end
 
@@ -137,7 +137,7 @@ describe "app" do
 
         post "/api/v1/notifications", from: CGI::escape(start_time.to_s), to: CGI::escape(end_time.to_s), user_ids: user.id
 
-        last_response.should be_ok
+        expect(last_response).to be_ok
         payload = JSON.parse last_response.body
         courses = payload[user.id.to_s]
         thread_ids = []
@@ -155,7 +155,7 @@ describe "app" do
         end_time = Time.now + 5.seconds
         
         post "/api/v1/notifications", from: CGI::escape(start_time.to_s), to: CGI::escape(end_time.to_s), user_ids: user.id
-        last_response.should be_ok
+        expect(last_response).to be_ok
         payload = JSON.parse last_response.body
         courses = payload[user.id.to_s]
         new_thread_ids = []
@@ -165,7 +165,7 @@ describe "app" do
             end
         end
 
-        (new_thread_ids.include? thread.id).should == false
+        expect(new_thread_ids.include? thread.id).to eq(false)
 
       end
 

--- a/spec/api/query_spec.rb
+++ b/spec/api/query_spec.rb
@@ -17,7 +17,7 @@ describe 'app' do
 
       let(:matched_thread) { parse(subject.body)['collection'].select { |t| t['id'] == thread.id.to_s }.first }
 
-      it { should be_ok }
+      it { is_expected.to be_ok }
 
       it 'returns thread with query match' do
         expect(matched_thread).to_not be_nil

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -18,8 +18,8 @@ describe 'app' do
         before (:each) { TaskHelpers::ElasticsearchHelper.refresh_indices }
         subject { get '/api/v1/search/threads', {course_id: course_id}.merge!(parameters) }
 
-        it { should be_ok }
-        it { should be_an_empty_response }
+        it { is_expected.to be_ok }
+        it { is_expected.to be_an_empty_response }
       end
 
       context 'without text parameter' do
@@ -36,9 +36,9 @@ describe 'app' do
         let(:course_id) { 'test/course/id' }
 
         def assert_result_total(expected_total)
-          last_response.should be_ok
+          expect(last_response).to be_ok
           result = parse(last_response.body)
-          result["total_results"].should == expected_total
+          expect(result["total_results"]).to eq(expected_total)
         end
 
         def create_and_delete_comment_or_thread(factory_name, text)
@@ -124,11 +124,11 @@ describe 'app' do
         end
 
         def assert_response_contains(expected_thread_indexes)
-          last_response.should be_ok
+          expect(last_response).to be_ok
           result = parse(last_response.body)
           actual_ids = Set.new get_result_ids(result)
           expected_ids = Set.new expected_thread_indexes.map { |i| threads[i].id.to_s }
-          actual_ids.should == expected_ids
+          expect(actual_ids).to eq(expected_ids)
         end
 
         it "by course_id" do
@@ -219,11 +219,11 @@ describe 'app' do
 
         def check_sort(sort_key, expected_thread_indexes)
           get "/api/v1/search/threads", text: "text", course_id: course_id, sort_key: sort_key
-          last_response.should be_ok
+          expect(last_response).to be_ok
           result = parse(last_response.body)
           actual_ids = get_result_ids(result)
           expected_ids = expected_thread_indexes.map { |i| threads[i].id.to_s }
-          actual_ids.should == expected_ids
+          expect(actual_ids).to eq(expected_ids)
         end
 
         it "by date" do
@@ -258,11 +258,11 @@ describe 'app' do
           result_ids = []
           (1..(num_pages + 1)).each do |i| # Go past the end to make sure non-existent pages are empty
             get "/api/v1/search/threads", text: "text", page: i, per_page: per_page
-            last_response.should be_ok
+            expect(last_response).to be_ok
             result = parse(last_response.body)
             result_ids += get_result_ids(result)
           end
-          result_ids.should == threads.reverse.map { |t| t.id.to_s }
+          expect(result_ids).to eq(threads.reverse.map { |t| t.id.to_s })
         end
 
         it "works correctly with page size 1" do
@@ -283,10 +283,10 @@ describe 'app' do
 
         def check_correction(original_text, corrected_text)
           get "/api/v1/search/threads", text: original_text
-          last_response.should be_ok
+          expect(last_response).to be_ok
           result = parse(last_response.body)
-          result["corrected_text"].should == corrected_text
-          result["collection"].first.should_not be_nil
+          expect(result["corrected_text"]).to eq(corrected_text)
+          expect(result["collection"].first).not_to be_nil
         end
 
         before(:each) do
@@ -337,10 +337,10 @@ describe 'app' do
           TaskHelpers::ElasticsearchHelper.refresh_indices
 
           get "/api/v1/search/threads", text: "abot", course_id: course_id
-          last_response.should be_ok
+          expect(last_response).to be_ok
           result = parse(last_response.body)
-          result["corrected_text"].should be_nil
-          result["collection"].should be_empty
+          expect(result["corrected_text"]).to be_nil
+          expect(result["collection"]).to be_empty
         end
       end
 
@@ -362,10 +362,10 @@ describe 'app' do
 
         test_text = lambda do |text, expected_total_results, expected_num_pages|
           get '/api/v1/search/threads', course_id: course_id, text: text, per_page: '10'
-          last_response.should be_ok
+          expect(last_response).to be_ok
           result = parse(last_response.body)
-          result["total_results"].should == expected_total_results
-          result["num_pages"].should == expected_num_pages
+          expect(result["total_results"]).to eq(expected_total_results)
+          expect(result["num_pages"]).to eq(expected_num_pages)
         end
 
         test_text.call("all", 100, 10)

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -448,7 +448,7 @@ describe "app" do
         user.reload
         read_states = user.read_states.where(course_id: thread.course_id).to_a
         read_date = read_states.first.last_read_times[thread.id.to_s]
-        read_date.should >= thread.updated_at
+        expect(read_date).to be >= thread.updated_at
       end
     end
 
@@ -519,7 +519,7 @@ describe "app" do
           # User's comments should be blanked out.
           user = User.where(external_id: '2').first
           comments = user.all_comments + user.all_comment_threads
-          expect(comments.count).should_not eq(0)
+          expect(expect(comments.count)).not_to eq(0)
           comments.each do |single_comment|
             if single_comment._type == 'CommentThread'
               expect(single_comment.title).to match(RETIRED_TITLE)
@@ -567,7 +567,7 @@ describe "app" do
           expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
           # User's comments should be blanked out.
           comments = user.all_comments + user.all_comment_threads
-          expect(comments.count).should_not eq(0)
+          expect(expect(comments.count)).not_to eq(0)
           comments.each do |single_comment|
             if single_comment._type == 'CommentThread'
               expect(single_comment.title).to match(RETIRED_TITLE)
@@ -640,7 +640,7 @@ describe "app" do
 
           # User's comments should all have new username.
           comments = user.all_comments + user.all_comment_threads
-          expect(comments.count).should_not eq(0)
+          expect(expect(comments.count)).not_to eq(0)
           comments.each do |single_comment|
             expect(single_comment.author_username).to match(new_username)
           end

--- a/spec/api/vote_spec.rb
+++ b/spec/api/vote_spec.rb
@@ -16,26 +16,26 @@ describe "app" do
         prev_down_votes = comment.down_votes_count
         put "/api/v1/comments/#{comment.id}/votes", user_id: user.id, value: "down"
         comment = Comment.find(comment.id)
-        comment.up_votes_count.should == prev_up_votes - 1
-        comment.down_votes_count.should == prev_down_votes + 1
+        expect(comment.up_votes_count).to eq(prev_up_votes - 1)
+        expect(comment.down_votes_count).to eq(prev_down_votes + 1)
       end
       it "returns 400 when the comment does not exist" do
         put "/api/v1/comments/does_not_exist/votes", user_id: User.first.id, value: "down"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
       end
       it "returns 400 when user_id is not provided" do
         put "/api/v1/comments/#{Comment.first.id}/votes", value: "down"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:user_id_is_required)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:user_id_is_required))
       end
       it "returns 400 when value is not provided or invalid" do
         put "/api/v1/comments/#{Comment.first.id}/votes", user_id: User.first.id
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:value_is_required)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:value_is_required))
         put "/api/v1/comments/#{Comment.first.id}/votes", user_id: User.first.id, value: "superdown"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:value_is_invalid)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:value_is_invalid))
       end
     end
     describe "DELETE /api/v1/comments/:comment_id/votes" do
@@ -46,8 +46,8 @@ describe "app" do
         prev_down_votes = comment.down_votes_count
         delete "/api/v1/comments/#{comment.id}/votes", user_id: user.id
         comment = Comment.find(comment.id)
-        comment.up_votes_count.should == prev_up_votes - 1
-        comment.down_votes_count.should == prev_down_votes
+        expect(comment.up_votes_count).to eq(prev_up_votes - 1)
+        expect(comment.down_votes_count).to eq(prev_down_votes)
       end
       it "unvote on the comment is idempotent" do
         user = User.first
@@ -58,18 +58,18 @@ describe "app" do
         # multiple calls to unvote endpoint should not change the data
         delete "/api/v1/comments/#{comment.id}/votes", user_id: user.id
         comment = Comment.find(comment.id)
-        comment.up_votes_count.should == prev_up_votes - 1
-        comment.down_votes_count.should == prev_down_votes
+        expect(comment.up_votes_count).to eq(prev_up_votes - 1)
+        expect(comment.down_votes_count).to eq(prev_down_votes)
       end
       it "returns 400 when the comment does not exist" do
         delete "/api/v1/comments/does_not_exist/votes", user_id: User.first.id
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
       end
       it "returns 400 when user_id is not provided" do
         delete "/api/v1/comments/#{Comment.first.id}/votes"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:user_id_is_required)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:user_id_is_required))
       end
     end
     describe "PUT /api/v1/threads/:thread_id/votes" do
@@ -80,8 +80,8 @@ describe "app" do
         prev_down_votes = thread.down_votes_count
         put "/api/v1/threads/#{thread.id}/votes", user_id: user.id, value: "down"
         thread = CommentThread.find(thread.id)
-        thread.up_votes_count.should == prev_up_votes - 1
-        thread.down_votes_count.should == prev_down_votes + 1
+        expect(thread.up_votes_count).to eq(prev_up_votes - 1)
+        expect(thread.down_votes_count).to eq(prev_down_votes + 1)
       end
       it "vote on the thread is idempotent" do
         user = User.first
@@ -91,26 +91,26 @@ describe "app" do
         put "/api/v1/threads/#{thread.id}/votes", user_id: user.id, value: "down"
         put "/api/v1/threads/#{thread.id}/votes", user_id: user.id, value: "down"
         thread = CommentThread.find(thread.id)
-        thread.up_votes_count.should == prev_up_votes - 1
-        thread.down_votes_count.should == prev_down_votes + 1
+        expect(thread.up_votes_count).to eq(prev_up_votes - 1)
+        expect(thread.down_votes_count).to eq(prev_down_votes + 1)
       end
       it "returns 400 when the thread does not exist" do
         put "/api/v1/threads/does_not_exist/votes", user_id: User.first.id, value: "down"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
       end
       it "returns 400 when user_id is not provided" do
         put "/api/v1/threads/#{CommentThread.first.id}/votes", value: "down"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:user_id_is_required)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:user_id_is_required))
       end
       it "returns 400 when value is not provided or invalid" do
         put "/api/v1/threads/#{CommentThread.first.id}/votes", user_id: User.first.id
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:value_is_required)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:value_is_required))
         put "/api/v1/threads/#{CommentThread.first.id}/votes", user_id: User.first.id, value: "superdown"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:value_is_invalid)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:value_is_invalid))
       end
     end
     describe "DELETE /api/v1/threads/:thread_id/votes" do
@@ -121,18 +121,18 @@ describe "app" do
         prev_down_votes = thread.down_votes_count
         delete "/api/v1/threads/#{thread.id}/votes", user_id: user.id
         thread = CommentThread.find(thread.id)
-        thread.up_votes_count.should == prev_up_votes - 1
-        thread.down_votes_count.should == prev_down_votes
+        expect(thread.up_votes_count).to eq(prev_up_votes - 1)
+        expect(thread.down_votes_count).to eq(prev_down_votes)
       end
       it "returns 400 when the comment does not exist" do
         delete "/api/v1/threads/does_not_exist/votes", user_id: User.first.id
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:requested_object_not_found)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:requested_object_not_found))
       end
       it "returns 400 when user_id is not provided" do
         delete "/api/v1/threads/#{CommentThread.first.id}/votes"
-        last_response.status.should == 400
-        parse(last_response.body).first.should == I18n.t(:user_id_is_required)
+        expect(last_response.status).to eq(400)
+        expect(parse(last_response.body).first).to eq(I18n.t(:user_id_is_required))
       end
     end
   end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -49,15 +49,15 @@ describe 'app' do
     context 'db check' do
       def test_db_check(response, is_success)
         db = double("db")
-        stub_const('Mongoid::Clients', Class.new).stub(:default).and_return(db)
+        allow(stub_const('Mongoid::Clients', Class.new)).to receive(:default).and_return(db)
         result = double('result')
-        result.stub(:ok?).and_return(response['ok'] == 1)
-        result.stub(:documents).and_return([response])
-        db.stub(:close).and_return(true)
-        db.stub(:reconnect).and_return(true)
-        db.stub(:options).and_return({read: {mode: :primary}})
+        allow(result).to receive(:ok?).and_return(response['ok'] == 1)
+        allow(result).to receive(:documents).and_return([response])
+        allow(db).to receive(:close).and_return(true)
+        allow(db).to receive(:reconnect).and_return(true)
+        allow(db).to receive(:options).and_return({read: {mode: :primary}})
         # should be checked twice, because it will retry
-        db.should_receive(:command).with({:isMaster => 1}).twice.and_return(result)
+        expect(db).to receive(:command).with({:isMaster => 1}).twice.and_return(result)
 
         body = parse(subject.body)
         if is_success
@@ -87,11 +87,11 @@ describe 'app' do
 
       it 'reports failure when db command raises an error' do
         db = double('db')
-        stub_const('Mongoid::Clients', Class.new).stub(:default).and_return(db)
-        db.stub(:close).and_return(true)
-        db.stub(:reconnect).and_return(true)
+        allow(stub_const('Mongoid::Clients', Class.new)).to receive(:default).and_return(db)
+        allow(db).to receive(:close).and_return(true)
+        allow(db).to receive(:reconnect).and_return(true)
         # should be checked twice, because it will retry
-        db.should_receive(:command).with({:isMaster => 1}).twice.and_raise(StandardError)
+        expect(db).to receive(:command).with({:isMaster => 1}).twice.and_raise(StandardError)
 
         expect(subject.status).to eq 500
         expect(parse(subject.body)).to eq({'OK' => false, 'check' => 'db'})

--- a/spec/lib/task_helpers_spec.rb
+++ b/spec/lib/task_helpers_spec.rb
@@ -12,7 +12,7 @@ describe TaskHelpers do
 
     def assert_alias_points_to_index(alias_name, index_name)
       test_alias = Elasticsearch::Model.client.indices.get_alias(name: alias_name).keys[0]
-      test_alias.should == index_name
+      expect(test_alias).to eq(index_name)
     end
 
     context("#move_alias") do
@@ -46,9 +46,9 @@ describe TaskHelpers do
       it "builds new index with content" do
         create(:comment_thread, body: 'the best test body', course_id: 'test_course_id')
         TaskHelpers::ElasticsearchHelper.refresh_indices
-        Elasticsearch::Model.client.search(
+        expect(Elasticsearch::Model.client.search(
             index: TaskHelpers::ElasticsearchHelper::INDEX_NAMES
-        )['hits']['total']['value'].should be > 0
+        )['hits']['total']['value']).to be > 0
       end
 
     end

--- a/spec/lib/tasks/search_rake_spec.rb
+++ b/spec/lib/tasks/search_rake_spec.rb
@@ -5,13 +5,13 @@ describe "search:rebuild_indices" do
   include_context "rake"
 
   before do
-    TaskHelpers::ElasticsearchHelper.stub(:rebuild_indices)
+    allow(TaskHelpers::ElasticsearchHelper).to receive(:rebuild_indices)
   end
 
   its(:prerequisites) { should include("environment") }
 
   it "calls rebuild_indices with defaults" do
-    TaskHelpers::ElasticsearchHelper.should_receive(:rebuild_indices).with(500, 5)
+    expect(TaskHelpers::ElasticsearchHelper).to receive(:rebuild_indices).with(500, 5)
 
     subject.invoke
   end
@@ -20,7 +20,7 @@ describe "search:rebuild_indices" do
     # Rake calls receive arguments as strings.
     batch_size = '100'
     extra_catchup_minutes = '10'
-    TaskHelpers::ElasticsearchHelper.should_receive(:rebuild_indices).with(
+    expect(TaskHelpers::ElasticsearchHelper).to receive(:rebuild_indices).with(
           batch_size.to_i, extra_catchup_minutes.to_i
     )
 
@@ -35,13 +35,13 @@ describe "search:catchup" do
   let(:comment_threads_index_name) { CommentThread.index_name }
 
   before do
-    TaskHelpers::ElasticsearchHelper.stub(:catchup_indices)
+    allow(TaskHelpers::ElasticsearchHelper).to receive(:catchup_indices)
   end
 
   its(:prerequisites) { should include("environment") }
 
   it "calls catchup with defaults" do
-    TaskHelpers::ElasticsearchHelper.should_receive(:catchup_indices).with(indices, anything, 500)
+    expect(TaskHelpers::ElasticsearchHelper).to receive(:catchup_indices).with(indices, anything, 500)
 
     subject.invoke(comments_index_name, comment_threads_index_name)
   end
@@ -50,7 +50,7 @@ describe "search:catchup" do
     # Rake calls receive arguments as strings.
     minutes = '2'
     batch_size = '100'
-    TaskHelpers::ElasticsearchHelper.should_receive(:catchup_indices).with(indices, anything, batch_size.to_i)
+    expect(TaskHelpers::ElasticsearchHelper).to receive(:catchup_indices).with(indices, anything, batch_size.to_i)
 
     subject.invoke(comments_index_name, comment_threads_index_name, minutes, batch_size)
   end

--- a/spec/lib/unicorn_helpers_spec.rb
+++ b/spec/lib/unicorn_helpers_spec.rb
@@ -9,13 +9,13 @@ describe UnicornHelpers do
 
     it "doesn't exit when index is valid" do
       # code 101 is special code recongnized by forum-supervisor.sh
-      lambda{subject}.should_not exit_with_code(101)
+      expect{subject}.not_to exit_with_code(101)
     end
 
     it "exits when index is invalid" do
       TaskHelpers::ElasticsearchHelper.delete_indices
       # code 101 is special code recongnized by forum-supervisor.sh
-      lambda{subject}.should exit_with_code(101)
+      expect{subject}.to exit_with_code(101)
     end
 
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -17,7 +17,7 @@ describe Comment do
   def test_unicode_data(text)
     comment = make_comment(author, course_thread, text)
     retrieved = Comment.find(comment._id)
-    retrieved.body.should == text
+    expect(retrieved.body).to eq(text)
   end
 
   include_examples "unicode data"

--- a/spec/models/comment_thread_spec.rb
+++ b/spec/models/comment_thread_spec.rb
@@ -51,7 +51,7 @@ describe CommentThread do
       seq = []
       rs = Comment.where(comment_thread_id: thread.id).order_by({"sk"=>1})
       rs.each.map {|c| seq << c.body}
-      seq.should == ["a", "b", "c", "d", "e", "f"]
+      expect(seq).to eq(["a", "b", "c", "d", "e", "f"])
 
     end
   end
@@ -107,8 +107,8 @@ describe CommentThread do
   def test_unicode_data(text)
     thread = make_thread(author, text, "unicode_course", commentable_id: "unicode_commentable")
     retrieved = CommentThread.find(thread._id)
-    retrieved.title.should == text
-    retrieved.body.should == text
+    expect(retrieved.title).to eq(text)
+    expect(retrieved.body).to eq(text)
   end
 
   include_examples "unicode data"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,12 +11,12 @@ describe User do
   end
 
   it "should have no votes if it never voted" do
-    reader.upvoted_ids.should == []
+    expect(reader.upvoted_ids).to eq([])
   end
 
   it "should have one vote if it voted once" do
-    reader.upvoted_ids.should == []
+    expect(reader.upvoted_ids).to eq([])
     reader.vote(thread, :up)
-    reader.upvoted_ids.should == [thread._id]
+    expect(reader.upvoted_ids).to eq([thread._id])
   end
 end

--- a/spec/presenters/thread_list_spec.rb
+++ b/spec/presenters/thread_list_spec.rb
@@ -18,7 +18,7 @@ describe ThreadListPresenter do
     it "handles unread threads" do
       pres = ThreadListPresenter.new(@threads, @reader, 'foo')
       pres.to_hash.each_with_index do |h, i|
-        h.should == ThreadPresenter.factory(@threads[i], @reader).to_hash
+        expect(h).to eq(ThreadPresenter.factory(@threads[i], @reader).to_hash)
       end
     end
 
@@ -27,13 +27,13 @@ describe ThreadListPresenter do
       @reader.save!
       pres = ThreadListPresenter.new(@threads, @reader, 'foo')
       pres.to_hash.each_with_index do |h, i|
-        h.should == ThreadPresenter.factory(@threads[i], @reader).to_hash
+        expect(h).to eq(ThreadPresenter.factory(@threads[i], @reader).to_hash)
       end
     end
 
     it "handles empty list of threads" do
       pres = ThreadListPresenter.new([], @reader, 'foo')
-      pres.to_hash.should == []
+      expect(pres.to_hash).to eq([])
     end
 
   end

--- a/spec/presenters/thread_spec.rb
+++ b/spec/presenters/thread_spec.rb
@@ -108,11 +108,11 @@ describe ThreadPresenter do
           # with response=false and recursive=false
           hash = ThreadPresenter.new(thread, @reader, false, num_comments, is_endorsed, nil).to_hash(false, 0, nil, false)
           check_thread_result(@reader, thread, hash)
-          ['children', 'resp_skip', 'resp_limit', 'resp_total'].each {|k| (hash.has_key? k).should be false }
+          ['children', 'resp_skip', 'resp_limit', 'resp_total'].each {|k| expect(hash.has_key? k).to be false }
           # with response=false and recursive=true
           hash = ThreadPresenter.new(thread, @reader, false, num_comments, is_endorsed, nil).to_hash(false, 0, nil, true)
           check_thread_result(@reader, thread, hash)
-          ['children', 'resp_skip', 'resp_limit', 'resp_total'].each {|k| (hash.has_key? k).should be false }
+          ['children', 'resp_skip', 'resp_limit', 'resp_total'].each {|k| expect(hash.has_key? k).to be false }
         end
       end
 
@@ -202,13 +202,13 @@ describe ThreadPresenter do
 
       pres = ThreadPresenter.new(nil, nil, nil, nil, nil, nil)
       responses = pres.merge_response_content([c0, c00, c01, c010])
-      responses.size.should == 1 # c0
-      responses[0]["id"].should == c0.id
-      responses[0]["children"].size.should == 2 # c00, c01
-      responses[0]["children"][0]["id"].should == c00.id
-      responses[0]["children"][1]["id"].should == c01.id
-      responses[0]["children"][1]["children"].size.should == 1 # c010
-      responses[0]["children"][1]["children"][0]["id"].should == c010.id
+      expect(responses.size).to eq(1) # c0
+      expect(responses[0]["id"]).to eq(c0.id)
+      expect(responses[0]["children"].size).to eq(2) # c00, c01
+      expect(responses[0]["children"][0]["id"]).to eq(c00.id)
+      expect(responses[0]["children"][1]["id"]).to eq(c01.id)
+      expect(responses[0]["children"][1]["children"].size).to eq(1) # c010
+      expect(responses[0]["children"][1]["children"][0]["id"]).to eq(c010.id)
     end
 
     it "handles orphaned child comments gracefully" do
@@ -224,10 +224,10 @@ describe ThreadPresenter do
 
       pres = ThreadPresenter.new(nil, nil, nil, nil, nil, nil)
       responses = pres.merge_response_content([c00, c000, c1, c10, c111])
-      responses.size.should == 1 # c1
-      responses[0]["id"].should == c1.id
-      responses[0]["children"].size.should == 1 # c10
-      responses[0]["children"][0]["id"].should == c10.id
+      expect(responses.size).to eq(1) # c1
+      expect(responses[0]["id"]).to eq(c1.id)
+      expect(responses[0]["children"].size).to eq(1) # c10
+      expect(responses[0]["children"][0]["id"]).to eq(c10.id)
     end
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -7,6 +7,7 @@ RSpec::Matchers.define :be_an_empty_response do
 end
 
 RSpec::Matchers.define :exit_with_code do |exp_code|
+  supports_block_expectations
   actual = nil
 
   match do |block|

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -17,11 +17,11 @@ RSpec::Matchers.define :exit_with_code do |exp_code|
     end
     actual and actual == exp_code
   end
-  failure_message_for_should do |block|
+  failure_message do |block|
     "expected block to call exit(#{exp_code}) but exit" +
         (actual.nil? ? " not called" : "(#{actual}) was called")
   end
-  failure_message_for_should_not do |block|
+  failure_message_when_negated do |block|
     "expected block not to call exit(#{exp_code})"
   end
   description do


### PR DESCRIPTION
This conversion is done by Transpec 3.4.0 with the following command:
    transpec

* 294 conversions
    from: obj.should
      to: expect(obj).to

* 240 conversions
    from: == expected
      to: eq(expected)

* 15 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 11 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 9 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 6 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 1 conversion
    from: >= expected
      to: be >= expected

* 1 conversion
    from: failure_message_for_should { }
      to: failure_message { }

* 1 conversion
    from: failure_message_for_should_not { }
      to: failure_message_when_negated { }

* 1 conversion
    from: lambda { }.should
      to: expect { }.to

* 1 conversion
    from: lambda { }.should_not
      to: expect { }.not_to

For more details: https://github.com/yujinakayama/transpec#supported-conversions