### PR TITLE
[BD-38] [TNL-8842] Fix clean-up when re-opening closed posts

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -66,7 +66,27 @@ end
 
 put "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   filter_blocked_content params["body"]
-  thread.update_attributes(params.slice(*%w[title body pinned closed commentable_id group_id thread_type]))
+  updated_content = params.slice(*%w[title body pinned closed commentable_id group_id thread_type close_reason_code])
+  # If a close reason code is provided, save it. If a thread is being reopened, clear the closed_by flag
+  if updated_content.has_key? CLOSED
+    if value_to_boolean(updated_content[CLOSED])
+      updated_content["closed_by"] = user
+    else
+      updated_content["closed_by"] = nil
+      updated_content["close_reason_code"] = nil
+    end
+  end
+  if updated_content.has_key? BODY and updated_content[BODY] != thread.body
+    edit_reason_code = params.fetch("edit_reason_code", nil)
+    thread.edit_history.build(
+      original_body: thread.body,
+      author: user,
+      reason_code: edit_reason_code,
+      editor_username: user.username,
+    )
+    thread.save
+  end
+  thread.update_attributes(updated_content)
 
   if thread.errors.any?
     error 400, thread.errors.full_messages.to_json


### PR DESCRIPTION
This fixes a few bugs that slipped through with the introduction of reason codes:

* The condition to clean-up the `closed_by` field when re-opening posts was depending on `close_reason_code` being specified
* The check whether the request was closing or opening the post didn't parse the parameter into a boolean, so `"False"` values still evaluated to `true`.
* The `close_reason_code` wasn't being cleared when re-opening the post.

As a side effect this also removes the requirement for `close_reason_code` to be present when setting the `closed_by` attribute, which seemed reasonable to me, but I can reintroduce if it was the intended behavior.