### PR TITLE
 feat: Add support for specifying edit and close reasons [BD-38] [TNL-8842] [BB-5011] 

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -85,7 +85,6 @@ put "#{APIPREFIX}/threads/:thread_id" do |thread_id|
         reason_code: edit_reason_code,
         editor_username: user.username,
       )
-      thread.save
     end
   end
   thread.update_attributes(updated_content)

--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -66,7 +66,29 @@ end
 
 put "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   filter_blocked_content params["body"]
-  thread.update_attributes(params.slice(*%w[title body pinned closed commentable_id group_id thread_type]))
+  updated_content = params.slice(*%w[title body pinned closed commentable_id group_id thread_type close_reason_code])
+  # If a close reason code is provided, save it. If a thread is being reopened, clear the closed_by flag
+  if params[:user_id]
+    if updated_content.has_key? CLOSED
+      if value_to_boolean(updated_content[CLOSED])
+        updated_content["closed_by"] = user
+      else
+        updated_content["closed_by"] = nil
+        updated_content["close_reason_code"] = nil
+      end
+    end
+    if updated_content.has_key? BODY and updated_content[BODY] != thread.body
+      edit_reason_code = params.fetch("edit_reason_code", nil)
+      thread.edit_history.build(
+        original_body: thread.body,
+        author: user,
+        reason_code: edit_reason_code,
+        editor_username: user.username,
+      )
+      thread.save
+    end
+  end
+  thread.update_attributes(updated_content)
 
   if thread.errors.any?
     error 400, thread.errors.full_messages.to_json

--- a/api/comments.rb
+++ b/api/comments.rb
@@ -64,7 +64,6 @@ put "#{APIPREFIX}/comments/:comment_id" do |comment_id|
         reason_code: edit_reason_code,
         editor_username: user.username,
       )
-      comment.save
     end
   end
   comment.update_attributes(updated_content)

--- a/api/comments.rb
+++ b/api/comments.rb
@@ -55,6 +55,18 @@ put "#{APIPREFIX}/comments/:comment_id" do |comment_id|
       updated_content["endorsement"] = new_endorsed_val ? endorsement : nil
     end
   end
+  if params[:user_id]
+    if updated_content.has_key? BODY and updated_content[BODY] != comment.body
+      edit_reason_code = params.fetch("edit_reason_code", nil)
+      comment.edit_history.build(
+        original_body: comment.body,
+        author: user,
+        reason_code: edit_reason_code,
+        editor_username: user.username,
+      )
+      comment.save
+    end
+  end
   comment.update_attributes(updated_content)
   if comment.errors.any?
     error 400, comment.errors.full_messages.to_json

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -2,6 +2,7 @@ require 'logger'
 require_relative 'concerns/searchable'
 require_relative 'content'
 require_relative 'constants'
+require_relative 'edit_history'
 
 logger = Logger.new(STDOUT)
 logger.level = Logger::WARN
@@ -52,7 +53,8 @@ class Comment < Content
   end
 
   belongs_to :comment_thread, index: true
-  belongs_to :author, class_name: 'User', index: true
+  belongs_to :author, class_name: 'User', inverse_of: :comments, index: true
+  embeds_many :edit_history, cascade_callbacks: true
 
   attr_accessible :body, :course_id, :anonymous, :anonymous_to_peers, :endorsed, :endorsement, :retired_username
 
@@ -127,6 +129,7 @@ class Comment < Content
                 "username" => author_username,
                 "depth" => depth,
                 "closed" => comment_thread.nil? ? false : comment_thread.closed,
+                "edit_history" => edit_history.map(&:to_hash),
                 "thread_id" => comment_thread_id,
                 "parent_id" => parent_ids[-1],
                 "commentable_id" => comment_thread.nil? ? nil : comment_thread.commentable_id,

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -2,6 +2,7 @@ require 'logger'
 require_relative 'concerns/searchable'
 require_relative 'content'
 require_relative 'constants'
+require_relative 'edit_history'
 
 logger = Logger.new(STDOUT)
 logger.level = Logger::WARN
@@ -34,8 +35,9 @@ class CommentThread < Content
   field :group_id, type: Integer
   field :pinned, type: Boolean
   field :retired_username, type: String, default: nil
+  field :close_reason_code, type: String, default: nil # string code that represents why a thread was closed.
 
-  index({author_id: 1, course_id: 1})
+  index({ author_id: 1, course_id: 1 })
 
   index_name = "comment_thread"
 
@@ -61,10 +63,13 @@ class CommentThread < Content
   end
 
   belongs_to :author, class_name: 'User', inverse_of: :comment_threads, index: true
+  belongs_to :closed_by, class_name: 'User', inverse_of: :threads_closed, optional: true
   has_many :comments, dependent: :destroy # Use destroy to invoke callback on the top-level comments
   has_many :activities, autosave: true
+  embeds_many :edit_history, cascade_callbacks: true
 
-  attr_accessible :title, :body, :course_id, :commentable_id, :anonymous, :anonymous_to_peers, :closed, :thread_type, :retired_username
+  attr_accessible :title, :body, :course_id, :commentable_id, :anonymous, :anonymous_to_peers, :closed,
+                  :thread_type, :retired_username, :close_reason_code, :closed_by
 
   validates_presence_of :thread_type
   validates_presence_of :context
@@ -139,12 +144,14 @@ class CommentThread < Content
 
   def to_hash(params={})
     as_document
-      .slice(THREAD_TYPE, TITLE, BODY, COURSE_ID, ANONYMOUS, ANONYMOUS_TO_PEERS, COMMENTABLE_ID, CREATED_AT, UPDATED_AT, AT_POSITION_LIST, CLOSED, CONTEXT, LAST_ACTIVITY_AT)
+      .slice(THREAD_TYPE, TITLE, BODY, COURSE_ID, ANONYMOUS, ANONYMOUS_TO_PEERS, COMMENTABLE_ID, CREATED_AT, UPDATED_AT, AT_POSITION_LIST, CLOSED, CONTEXT, LAST_ACTIVITY_AT, CLOSE_REASON_CODE)
       .merge!("id" => _id,
               "user_id" => author_id,
               "username" => author_username,
               "votes" => votes.slice(COUNT, UP_COUNT, DOWN_COUNT, POINT),
               "abuse_flaggers" => abuse_flaggers,
+              "edit_history" => edit_history.map(&:to_hash),
+              "closed_by" => closed_by? ? closed_by.username : nil,
               "tags" => [],
               "type" => THREAD,
               "group_id" => group_id,

--- a/models/constants.rb
+++ b/models/constants.rb
@@ -29,5 +29,13 @@ EXTERNAL_ID = "external_id".freeze
 COMMENT = "comment".freeze
 THREAD = "thread".freeze
 
+REASON_CODE = "reason_code".freeze
+CLOSE_REASON_CODE = "close_reason_code".freeze
+EDIT_REASON_CODE = "edit_reason_code".freeze
+ORIGINAL_BODY = "original_body".freeze
+EDIT_HISTORY = "edit_history".freeze
+EDITOR_USERNAME = "editor_username".freeze
+
+
 RETIRED_TITLE = "[deleted]".freeze
 RETIRED_BODY = "[deleted]".freeze

--- a/models/edit_history.rb
+++ b/models/edit_history.rb
@@ -1,4 +1,3 @@
-
 class EditHistory
   include Mongoid::Document
   include Mongoid::Timestamps::Created
@@ -10,6 +9,7 @@ class EditHistory
   belongs_to :author, class_name: 'User', inverse_of: :comment_edits
 
   embedded_in :comment
+
   def to_hash
     as_document.slice(ORIGINAL_BODY, REASON_CODE, EDITOR_USERNAME, CREATED_AT)
   end

--- a/models/edit_history.rb
+++ b/models/edit_history.rb
@@ -1,0 +1,16 @@
+
+class EditHistory
+  include Mongoid::Document
+  include Mongoid::Timestamps::Created
+
+  field :original_body, type: String
+  field :reason_code, type: String
+  field :editor_username, type: String
+
+  belongs_to :author, class_name: 'User', inverse_of: :comment_edits
+
+  embedded_in :comment
+  def to_hash
+    as_document.slice(ORIGINAL_BODY, REASON_CODE, EDITOR_USERNAME, CREATED_AT)
+  end
+end

--- a/models/user.rb
+++ b/models/user.rb
@@ -18,6 +18,7 @@ class User
   has_many :comments, inverse_of: :author
   has_many :comment_threads, inverse_of: :author
   has_many :activities, class_name: "Notification", inverse_of: :actor
+  has_many :threads_closed, class_name: 'CommentThread', inverse_of: :closed_by
   has_and_belongs_to_many :notifications, inverse_of: :receivers
 
   validates_presence_of :external_id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -204,7 +204,7 @@ def check_thread_result(user, thread, hash, is_json=false)
     if is_json
       item.merge("created_at"=>item["created_at"].utc.strftime("%Y-%m-%dT%H:%M:%SZ"))
     else
-      item.merge
+      item
     end
   end
   expect(hash["edit_history"]).to eq edit_history

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
   config.include Rack::Test::Methods
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = ".rspec-test-status"
 end
 
 Mongoid.configure do |config|
@@ -169,6 +170,7 @@ def check_thread_result(user, thread, hash, is_json=false)
   expected_keys += %w(anonymous anonymous_to_peers at_position_list closed user_id)
   expected_keys += %w(username votes abuse_flaggers tags type group_id pinned)
   expected_keys += %w(comments_count unread_comments_count read endorsed last_activity_at)
+  expected_keys += %w(closed_by edit_history)
   # these keys are checked separately, when desired, using check_thread_response_paging.
   actual_keys = hash.keys - [
     "children", "endorsed_responses", "non_endorsed_responses", "resp_skip",
@@ -184,6 +186,7 @@ def check_thread_result(user, thread, hash, is_json=false)
   expect(hash["commentable_id"]).to eq thread.commentable_id
   expect(hash["at_position_list"]).to eq thread.at_position_list
   expect(hash["closed"]).to eq thread.closed
+  expect(hash["closed_by"]).to eq thread.closed_by
   expect(hash["user_id"]).to eq thread.author.id
   expect(hash["username"]).to eq thread.author.username
   expect(hash["votes"]["point"]).to eq thread.votes["point"]
@@ -197,6 +200,14 @@ def check_thread_result(user, thread, hash, is_json=false)
   expect(hash["pinned"]).to eq thread.pinned?
   expect(hash["endorsed"]).to eq thread.endorsed?
   expect(hash["comments_count"]).to eq thread.comments.length
+  edit_history = thread.edit_history.map(&:to_hash).map do |item|
+    if is_json
+      item.merge("created_at"=>item["created_at"].utc.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    else
+      item.merge
+    end
+  end
+  expect(hash["edit_history"]).to eq edit_history
   hash["context"] = thread.context
 
   if is_json


### PR DESCRIPTION
Adds support for specifiying an optional edit reason when editing a post which is preserved when the post is edited by a user that isn't the original author (for instance a moderator). The edit reason can be used by the platform to indicate why a post or comment was changed, for instance if it contained answers. It also stores the user that made this change and retains the previous version of the body in this case.

It also adds support for a post close reason code. This can be specified when closing the post. The user closing a post is also tracked as closed_by.

Note: Was previously merged as #356 but that changed the API in a way that broke the legacy UI.