### PR TITLE
fix: update nokogiri and rubyzip gems for security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'mongoid_magic_counter_cache'
 # function 'handle_threads_query'.
 gem 'will_paginate_mongoid', "~>2.0"
 gem 'rdiscount'
-gem 'nokogiri', "~>1.8.1"
+gem 'nokogiri', "~> 1.8.1"
 
 gem 'elasticsearch', '~> 7.8.0'
 gem 'elasticsearch-model', '~> 7.1.0'
@@ -44,6 +44,8 @@ gem 'elasticsearch-model', '~> 7.1.0'
 gem 'dalli'
 
 gem 'rest-client'
+
+gem 'rubyzip', '~> 1.2.2'
 
 group :test do
   gem 'codecov', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,7 @@ GEM
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.4)
     safe_yaml (1.0.4)
     shellany (0.0.1)
     simplecov (0.19.0)
@@ -248,6 +249,7 @@ DEPENDENCIES
   rspec (~> 3.6.0)
   rspec-collection_matchers
   rspec-its
+  rubyzip (~> 1.2.2)
   sinatra
   sinatra-param (~> 1.4)
   unicorn


### PR DESCRIPTION
### [TNL-9579](https://openedx.atlassian.net/browse/TNL-9579)

#### Description

Update ruby gems with security vulnerabilities.

- nokogiri
- rubyzip