### PR TITLE
fix: update Ruby gems to fix security vulnerabilities.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'sinatra-param', '~> 1.4'
 
 gem 'yajl-ruby', '~> 1.3.1'
 
-gem 'activemodel'
+gem 'activemodel', '~> 6.0.3.1'
 gem 'protected_attributes_continued'
 
 gem 'mongoid'
@@ -46,6 +46,14 @@ gem 'dalli'
 gem 'rest-client'
 
 gem 'rubyzip', '~> 1.2.2'
+
+gem 'ffi', '~> 1.9.24'
+
+gem 'faye-websocket', '~> 0.11.0'
+
+gem 'addressable', '~> 2.8.0'
+
+gem 'activesupport', '~> 6.0.3.1'
 
 group :test do
   gem 'codecov', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,27 +16,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.2.1)
-      activesupport (= 6.0.2.1)
-      builder (~> 3.1)
-    activesupport (6.0.2.1)
+    activemodel (6.0.3.7)
+      activesupport (= 6.0.3.7)
+    activesupport (6.0.3.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     bson (4.7.0)
     bson_ext (1.5.1)
-    builder (3.2.3)
     codecov (0.2.6)
       colorize
       json
       simplecov
     coderay (1.1.1)
     colorize (0.8.1)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.9)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     dalli (2.7.6)
@@ -64,13 +62,17 @@ GEM
       multi_json
     enumerize (2.1.2)
       activesupport (>= 3.2)
+    eventmachine (1.2.7)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
     faker (1.7.3)
       i18n (~> 0.5)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    faye-websocket (0.11.1)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
+    ffi (1.9.25)
     formatador (0.2.5)
     guard (2.14.1)
       formatador (>= 0.2.4)
@@ -101,7 +103,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
-    minitest (5.14.0)
+    minitest (5.15.0)
     mongo (2.5.3)
       bson (>= 4.3.0, < 5.0.0)
     mongoid (7.0.5)
@@ -136,7 +138,7 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    public_suffix (2.0.5)
+    public_suffix (4.0.6)
     rack (1.6.8)
     rack-protection (1.5.3)
       rack
@@ -191,7 +193,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
-    tzinfo (1.2.6)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -203,18 +205,23 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     will_paginate (3.1.6)
     will_paginate_mongoid (2.0.1)
       mongoid
       will_paginate (~> 3.0)
     yajl-ruby (1.3.1)
-    zeitwerk (2.2.2)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel
+  activemodel (~> 6.0.3.1)
+  activesupport (~> 6.0.3.1)
+  addressable (~> 2.8.0)
   bson
   bson_ext
   bundler
@@ -227,6 +234,8 @@ DEPENDENCIES
   enumerize
   factory_girl (~> 4.0)
   faker (~> 1.6)
+  faye-websocket (~> 0.11.0)
+  ffi (~> 1.9.24)
   guard
   guard-unicorn
   i18n


### PR DESCRIPTION
### [TNL-9580](https://openedx.atlassian.net/browse/TNL-9580)

#### Description

Update ruby gems with security vulnerabilities.

- **ffi**
- **faye-websocket**
- **addressable**
- **activesupport**
     - **activemodel (done as this is a dependancy)**