### PR TITLE
feat!: Use explicitly-specified user ids for closing and editing users, and add sorting by flags [BD-38] [TN-9809]

### DIFF
--- a/spec/api/comment_spec.rb
+++ b/spec/api/comment_spec.rb
@@ -112,7 +112,7 @@ describe 'Comment API' do
     it 'updates body correctly' do
       comment = thread.comments.first
       original_body = comment.body
-      put "/api/v1/comments/#{comment.id}", body: 'new body', user_id: User.first.id, edit_reason_code: "test_reason"
+      put "/api/v1/comments/#{comment.id}", body: 'new body', editing_user_id: User.first.id, edit_reason_code: "test_reason"
       expect(last_response).to be_ok
       comment.reload
       expect(comment.body).to eq 'new body'

--- a/spec/api/comment_thread_spec.rb
+++ b/spec/api/comment_thread_spec.rb
@@ -727,7 +727,7 @@ describe 'app' do
       it "update close reason for thread" do
         thread = CommentThread.first
         expect(thread.closed).to be false
-        put "/api/v1/threads/#{thread.id}", closed: true, user_id: User.first.id, close_reason_code: "test_code"
+        put "/api/v1/threads/#{thread.id}", closed: true, closing_user_id: User.first.id, close_reason_code: "test_code"
         last_response.should be_ok
         changed_thread = CommentThread.find(thread.id)
         expect(changed_thread.closed).to eq true
@@ -738,9 +738,9 @@ describe 'app' do
       it "closing and reopening thread clears reason code" do
         thread = CommentThread.first
         expect(thread.closed).to be false
-        put "/api/v1/threads/#{thread.id}", closed: true, user_id: User.first.id, close_reason_code: "test_code"
+        put "/api/v1/threads/#{thread.id}", closed: true, closing_user_id: User.first.id, close_reason_code: "test_code"
         last_response.should be_ok
-        put "/api/v1/threads/#{thread.id}", closed: false, user_id: User.first.id
+        put "/api/v1/threads/#{thread.id}", closed: false, closing_user_id: User.first.id
         changed_thread = CommentThread.find(thread.id)
         expect(changed_thread.closed).to be false
         expect(changed_thread.close_reason_code).to be_nil


### PR DESCRIPTION
The closing and editing users now need to be manually specified since the default is to use the author.
Also adds support for sorting user comments by flagged status.
