### PR TITLE
feat: add support for fetching course stats for specific users [BD-38] [INF-298] 

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -17,6 +17,8 @@ get "#{APIPREFIX}/users/:course_id/stats" do |course_id|
   per_page = (params["per_page"] || DEFAULT_PER_PAGE).to_i
   per_page = DEFAULT_PER_PAGE if per_page <= 0
 
+  usernames = params.fetch("usernames", '').split(',')
+
   # There are two sorts available, activity sort and flagged sort.
   sort_by = params["sort_key"]
   if sort_by == "flagged"
@@ -34,11 +36,14 @@ get "#{APIPREFIX}/users/:course_id/stats" do |course_id|
     ]
   end
 
-  paginated_stats = User
-                      .where("course_stats.course_id" => course_id)
-                      .only(:username, :'course_stats.$')  # Only return the username and the course stats document matched above.
-                      .order_by(sort_criterion)
-                      .paginate(:page => page, :per_page => per_page)
+  stats_query = User
+                  .where("course_stats.course_id" => course_id)
+                  .only(:username, :'course_stats.$') # Only return the username and the course stats document matched above.
+                  .order_by(sort_criterion)
+  unless usernames.empty?
+    stats_query = stats_query.in(username: usernames)
+  end
+  paginated_stats = stats_query.paginate(:page => page, :per_page => per_page)
   total_count = paginated_stats.total_entries
 
   data = paginated_stats.to_a.map do |user_stats|

--- a/api/users.rb
+++ b/api/users.rb
@@ -43,13 +43,14 @@ get "#{APIPREFIX}/users/:course_id/stats" do |course_id|
   	stats_query = stats_query.order_by(sort_criterion)
     paginated_stats = stats_query.paginate(:page => page, :per_page => per_page)
     total_count = paginated_stats.total_entries
+    num_pages = [1, (total_count / per_page.to_f).ceil].max
   else
     # If a list of usernames is provided, then sort by the order in which those names appear
     stats_query = stats_query.in(username: usernames)
     paginated_stats = stats_query.sort_by {|u| usernames.index(u.username)}
     # Search results are not paginated
     total_count = paginated_stats.length
-    per_page = total_count
+    num_pages = 1
   end
 
   data = paginated_stats.to_a.map do |user_stats|
@@ -60,7 +61,7 @@ get "#{APIPREFIX}/users/:course_id/stats" do |course_id|
 
   {
     user_stats: data,
-    num_pages: [1, (total_count / per_page.to_f).ceil].max,
+    num_pages: num_pages,
     page: page,
     count: total_count,
   }.to_json

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -449,6 +449,22 @@ describe "app" do
         expect(last_response.status).to eq(200)
         res = parse(last_response.body)
         expect(res["user_stats"]).to eq expected_result
+        end
+
+      it "returns user's stats filtered by user with default/activity sort" do
+        usernames = %w[userauthor-1 userauthor-2 userauthor-3].sample(2).join(',')
+        full_data = build_structure_and_response course_id
+        # Sort the map entries using the default sort
+        expected_result = full_data.values
+                                       .select {|val| usernames.include? val["username"]}
+                                       .sort_by { |val| [val["threads"], val["responses"], val["replies"]] }
+                                       .reverse
+
+        get "/api/v1/users/#{course_id}/stats", usernames: usernames
+        expect(last_response.status).to eq(200)
+        res = parse(last_response.body)
+        puts res
+        expect(res["user_stats"]).to eq expected_result
       end
 
       it "returns user's stats with flagged sort" do

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -452,18 +452,17 @@ describe "app" do
         end
 
       it "returns user's stats filtered by user with default/activity sort" do
-        usernames = %w[userauthor-1 userauthor-2 userauthor-3].sample(2).join(',')
+        usernames = %w[userauthor-1 userauthor-2 userauthor-3].sample(2)
+        usernames = usernames.shuffle.join(',')
         full_data = build_structure_and_response course_id
         # Sort the map entries using the default sort
         expected_result = full_data.values
                                        .select {|val| usernames.include? val["username"]}
-                                       .sort_by { |val| [val["threads"], val["responses"], val["replies"]] }
-                                       .reverse
+                                       .sort_by { |val| usernames.index val["username"] }
 
         get "/api/v1/users/#{course_id}/stats", usernames: usernames
         expect(last_response.status).to eq(200)
         res = parse(last_response.body)
-        puts res
         expect(res["user_stats"]).to eq expected_result
       end
 


### PR DESCRIPTION
Adds support to the user course stats API to fetch data only for users specified in the username param.
