### PR TITLE
feat: Maintain last activity timestamps for users so stats can be sorted on that basis [BD-38] [INF-251]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,5 @@ gem "rack-timeout"
 gem "i18n"
 gem "rack-contrib", :git => 'https://github.com/rack/rack-contrib.git', :ref => '6ff3ca2b2d988911ca52a2712f6a7da5e064aa27'
 
+
+gem "timecop", "~> 0.9.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
+    timecop (0.9.5)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -262,6 +263,7 @@ DEPENDENCIES
   rubyzip (~> 1.2.2)
   sinatra
   sinatra-param (~> 1.4)
+  timecop (~> 0.9.5)
   unicorn
   webmock (~> 3.0.1)
   will_paginate_mongoid (~> 2.0)

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -68,6 +68,11 @@ class Comment < Content
   before_destroy :destroy_children
   before_create :set_thread_last_activity_at
   before_save :set_sk
+  before_save do
+    unless anonymous or anonymous_to_peers or not body_changed?
+      author.update_activity_timestamp course_id
+    end
+  end
   after_destroy do
     unless anonymous or anonymous_to_peers
       if parent_id.nil?

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -81,6 +81,11 @@ class CommentThread < Content
 
   before_create :set_last_activity_at
   after_update :clear_endorsements
+  before_save do
+    unless anonymous or anonymous_to_peers or not body_changed?
+      author.update_activity_timestamp course_id
+    end
+  end
   before_destroy :destroy_subscriptions
   after_destroy do
     unless anonymous or anonymous_to_peers

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -395,7 +395,8 @@ describe "app" do
       expected_data[content.author.external_id]["inactive_flags"] += content.historical_abuse_flaggers.empty? ? 0 : 1
     end
 
-    def build_structure_and_response(course_id, authors, build_initial_stats=true)
+    def build_structure_and_response(course_id, authors, build_initial_stats = true, with_timestamps = false)
+      Timecop.scale(1000)
       expected_data = Hash[authors.map { |author| [
         author.external_id,
         {
@@ -412,18 +413,21 @@ describe "app" do
       (0..10).each do
         thread_author = authors.sample
         expected_data[thread_author.external_id]["threads"] += 1
+        expected_data[thread_author.external_id]["last_activity_at"] = Time.now.strftime("%Y-%m-%dT%H:%M:%SZ") if with_timestamps
         thread = make_thread(thread_author, Faker::Lorem.sentence, course_id, Faker::Lorem.word)
         add_flags(thread, expected_data)
         # For each thread create 5 random comments with random authors
         (0..5).each do
           comment_author = authors.sample
           expected_data[comment_author.external_id]["responses"] += 1
+          expected_data[comment_author.external_id]["last_activity_at"] = Time.now.strftime("%Y-%m-%dT%H:%M:%SZ") if with_timestamps
           comment = make_comment(comment_author, thread, Faker::Lorem.sentence)
           add_flags(comment, expected_data)
           # For each comment create 3 random replies with random authors
           (0..2).each do
             reply_author = authors.sample
             expected_data[reply_author.external_id]["replies"] += 1
+            expected_data[reply_author.external_id]["last_activity_at"] = Time.now.strftime("%Y-%m-%dT%H:%M:%SZ") if with_timestamps
             reply = make_comment(reply_author, comment, Faker::Lorem.sentence)
             add_flags(reply, expected_data)
           end
@@ -432,6 +436,7 @@ describe "app" do
       if build_initial_stats
         authors.map { |author| author.build_course_stats(course_id) }
       end
+      Timecop.return
       expected_data
     end
 
@@ -461,13 +466,21 @@ describe "app" do
         full_data = build_structure_and_response course_id, authors
         # Sort the map entries using the default sort
         expected_result = full_data.values
-                                       .select {|val| usernames.include? val["username"]}
-                                       .sort_by { |val| usernames.index val["username"] }
+                                   .select { |val| usernames.include? val["username"] }
+                                   .sort_by { |val| usernames.index val["username"] }
 
         get "/api/v1/users/#{course_id}/stats", usernames: usernames
         expect(last_response.status).to eq(200)
         res = parse(last_response.body)
         expect(res["user_stats"]).to eq expected_result
+      end
+
+      it "returns user's stats with recency sort" do
+        get "/api/v1/users/#{course_id}/stats", sort_key: "recency", with_timestamps: true
+        expect(last_response.status).to eq(200)
+        res = parse(last_response.body)
+        sorted_order = res["user_stats"].sort_by { |val| [val["last_activity_at"], val["username"]] }.reverse
+        expect(res["user_stats"]).to eq(sorted_order)
       end
 
       it "returns user's stats with flagged sort" do


### PR DESCRIPTION
Each time a user edits a thread or comment, update their activity timestamp so their course activity statistics include their lastest activity timestamp.