### PR TITLE
fix: add index for course id in user stats [BD-38]

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -27,6 +27,7 @@ class User
   validates_uniqueness_of :username
 
   index( {external_id: 1}, {unique: true, background: true} )
+  index( {'course_stats.course_id': 1}, {background: true} )
 
   logger = Logger.new(STDOUT)
   logger.level = Logger::WARN

--- a/scripts/db/migrate-010-user-course_stats-course_id-index.js
+++ b/scripts/db/migrate-010-user-course_stats-course_id-index.js
@@ -1,0 +1,1 @@
+db.users.ensureIndex({'course_stats.course_id': 1}, { background: true })

--- a/scripts/db/revert-migrate-010-user-course_stats-course_id-index.js
+++ b/scripts/db/revert-migrate-010-user-course_stats-course_id-index.js
@@ -1,0 +1,1 @@
+db.users.dropIndex({'course_stats.course_id': 1})


### PR DESCRIPTION
The query to look up users by which ones have a course stat for a particular course is very slow when there are a large number of courses and users. This change adds an index for that field so that looking up users based on their course stats should be much faster.
