### PR TITLE
feat: Add support for filtering active threads using the same params as all threads [BD-38]

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -393,6 +393,14 @@ end
 
 DFLT_COURSE_ID = "xyz"
 
+def setup_thread_with_comments(author, title,  comment_count=5)
+  thread = make_thread author, title, DFLT_COURSE_ID, "pdq"
+  comment_count.times do |i|
+    make_comment author, thread, Faker::Lorem.sentence
+  end
+  thread
+end
+
 def setup_10_threads
   User.all.delete
   Content.all.delete


### PR DESCRIPTION
This commit adds support for filtering the active threads endpoint using the same parameters that can be used to filter the all threads endpoint.


**Note:**

This changes the way sorting and pagination works with this API. Since this is an API used by the legacy experience as well, that would impact the existing experience. 

Here's what's changed:
- The new pagination no longer supports arbitrarily large page numbers. i.e. you can't ask for page number 10,000 and get a result unless there are actually 10,000 pages. Earlier, it would return the last page in such cases. 
- Earlier, the threads would be sorted by the latest activity by the user. Now it can no longer be sorted that way, instead it is sorted by latest activity by **any user**. In order to support ordering the old way, the sorting needs to happen on the Ruby side. i.e. it needs to load all user active threads, and then sort them this way. I currently can't see any performance non-intenstive way of solving this issue. 