### PR TITLE
fix: pagination behaviour of user active threads API [BD-38]

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -157,7 +157,7 @@ get "#{APIPREFIX}/users/:user_id/active_threads" do |user_id|
 
   threads_data = handle_threads_query(
     threads,
-    params["user_id"],
+    user_id,
     params["course_id"],
     get_group_ids_from_params(params),
     params["author_id"],
@@ -173,7 +173,7 @@ get "#{APIPREFIX}/users/:user_id/active_threads" do |user_id|
     raw_query: raw_query
   )
 
-  if sort_key == 'user_activity'
+  if raw_query
     num_pages = [1, (threads_data.count / per_page.to_f).ceil].max
     page = [num_pages, [1, page].max].min
 

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -239,7 +239,9 @@ helpers do
         comment_threads.batch_size(CommentService.config["manual_pagination_batch_size"].to_i).each do |thread|
          thread_key = thread._id.to_s
           if !read_dates.has_key?(thread_key) || read_dates[thread_key] < thread.last_activity_at
-            if skipped >= to_skip or raw_query
+            if raw_query
+              threads << thread
+            elsif skipped >= to_skip
               if threads.length == per_page
                 has_more = true
                 break


### PR DESCRIPTION
When using the default `user_activity` filter for the active threads API, the
pagination and sorting happens in Ruby instead of MongoDB. In addition, when
using the unread filter, the pagination mechanism is different. This code
introduces a fix for when they are both used together.
