### PR TITLE
fix: pagination for user stats api [BD-38]

### DIFF
--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -516,6 +516,7 @@ describe "app" do
       end
 
       it "returns user's stats with recency sort" do
+        build_structure_and_response course_id, authors
         get "/api/v1/users/#{course_id}/stats", sort_key: "recency", with_timestamps: true
         expect(last_response.status).to eq(200)
         res = parse(last_response.body)


### PR DESCRIPTION
The user stats API had a few issues that were breaking pagination. First of all the total count of entries was reported
as the count after limiting to the per-page limit. This meant that the count would be limited to the page count even
if there were more entries. This commit adds a facet to the query that fetches the total count, and the data after
limiting. Another issue was using skip after limit, which is the incorrect order. This commit fixes that.