### PR TITLE
[BD-38][INF-544][BB-6682] feat: implement reverse_order parameter

### DIFF
--- a/api/comment_threads.rb
+++ b/api/comment_threads.rb
@@ -62,7 +62,9 @@ get "#{APIPREFIX}/threads/:thread_id" do |thread_id|
   unless (resp_limit <= size_limit)
     error 400, [t(:param_exceeds_limit, :param => resp_limit, :limit => size_limit)].to_json
   end
-  presenter.to_hash(bool_with_responses, resp_skip, resp_limit, bool_recursive, bool_flagged_comments).to_json
+  presenter.to_hash(
+    bool_with_responses, resp_skip, resp_limit, bool_recursive, bool_flagged_comments, bool_reverse_order
+  ).to_json
 end
 
 put "#{APIPREFIX}/threads/:thread_id" do |thread_id|

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -143,6 +143,10 @@ helpers do
     value_to_boolean params["flagged_comments"]
   end
 
+  def bool_reverse_order
+    value_to_boolean params["reverse_order"]
+  end
+
   def handle_paged_threads_query(paged_comment_threads)
 
   end

--- a/spec/presenters/thread_spec.rb
+++ b/spec/presenters/thread_spec.rb
@@ -167,6 +167,19 @@ describe ThreadPresenter do
         end
       end
 
+      it "handles reversed_order and recursive with skip and limit" do
+        @threads_with_num_comments.each do |thread, num_comments|
+          is_endorsed = num_comments > 0 && endorse_responses
+          [1, 2, 3, 9, 10, 11, 1000].each do |limit|
+            [0, 1, 2, 9, 10, 11, 1000].each do |skip|
+              hash = ThreadPresenter.new(thread, @reader, false, num_comments, is_endorsed, nil).to_hash(true, skip, limit, true, false, true)
+              check_thread_result(@reader, thread, hash)
+              check_thread_response_paging(thread, hash, skip, limit, false, false, true)
+            end
+          end
+        end
+      end
+
       it "fails with invalid arguments" do
         @threads_with_num_comments.each do |thread, num_comments|
           is_endorsed = num_comments > 0 && endorse_responses

--- a/spec/presenters/thread_spec.rb
+++ b/spec/presenters/thread_spec.rb
@@ -158,6 +158,15 @@ describe ThreadPresenter do
         end
       end
 
+      it "handles reversed_order and recursive" do
+        @threads_with_num_comments.each do |thread, num_comments|
+          is_endorsed = num_comments > 0 && endorse_responses
+          hash = ThreadPresenter.new(thread, @reader, false, num_comments, is_endorsed, nil).to_hash(true, 0, default_resp_limit, true, false, true)
+          check_thread_result(@reader, thread, hash)
+          check_thread_response_paging(thread, hash, 0, default_resp_limit, false, false, true)
+        end
+      end
+
       it "fails with invalid arguments" do
         @threads_with_num_comments.each do |thread, num_comments|
           is_endorsed = num_comments > 0 && endorse_responses


### PR DESCRIPTION
## Description

- Added `reverse_order` query parameter to the threads endpoint.
- Modified `merge_response_content` to support reversed content order.

## Testing instructions

1. Open Discussion for some course.
2. Create a discussion, add two responses, add comments for both of them.
3. Specify the thread ID (you can find it in the address bar) and course ID, and run the following ([httpie](https://github.com/httpie/httpie) used):
    ```
    http http://127.0.0.1:4567/api/v1/threads/<YOUR_THREAD_ID> "X-EDX-API-KEY: forumapikey" course_id==<YOUR_COURSE_ID> with_responses==True user_id==4 mark_as_read==False recursive==True resp_skip==0 reverse_order==false
    ```
    You should see a thread with comments ordered by the creation date.
4. Run the command from the previous point, but change `reverse_order==false` to `reverse_order==true`. You should see threads and comments in the reversed order.
5. You can specify `resp_limit==1` to verify that the reverse ordering works with pagination.