### PR TITLE
feat: operators can prefix elasticsearch indexes for multi-tenancy

### DIFF
--- a/api/search.rb
+++ b/api/search.rb
@@ -47,7 +47,7 @@ def get_thread_ids(context, group_ids, local_params, search_text)
     }
   }
 
-  response = Elasticsearch::Model.client.search(index: TaskHelpers::ElasticsearchHelper::INDEX_NAMES, body: body)
+  response = Elasticsearch::Model.client.search(index: TaskHelpers::ElasticsearchHelper::index_names, body: body)
 
   thread_ids = Set.new
   response['hits']['hits'].each do |hit|
@@ -81,7 +81,7 @@ def get_suggested_text(search_text)
     }
   }
 
-  response = Elasticsearch::Model.client.search(index: TaskHelpers::ElasticsearchHelper::INDEX_NAMES, body: body)
+  response = Elasticsearch::Model.client.search(index: TaskHelpers::ElasticsearchHelper::index_names, body: body)
   body_suggestions = response['suggest'].fetch('body_suggestions', [])
   title_suggestions = response['suggest'].fetch('title_suggestions', [])
 

--- a/app.rb
+++ b/app.rb
@@ -67,8 +67,9 @@ Mongo::Logger.logger.level = ENV["ENABLE_MONGO_DEBUGGING"] ? Logger::DEBUG : Log
 # NOTE: You can also add a logger, but it will log some FATAL warning during index creation.
 # Example: Elasticsearch::Client.new(logger: get_logger('elasticsearch', Logger::WARN))
 Elasticsearch::Model.client = Elasticsearch::Client.new(
-    host: CommentService.config[:elasticsearch_server],
-    log: false
+    url: CommentService.config[:elasticsearch_server],
+    log: false,
+    transport_options: CommentService.config[:elasticsearch_transport_options],
 )
 
 # Setup i18n

--- a/config/application.yml
+++ b/config/application.yml
@@ -7,3 +7,11 @@ default_locale: <%= ENV['SERVICE_LANGUAGE'] || 'en-US' %>
 manual_pagination_batch_size: <%= ENV['MANUAL_PAGINATION_BATCH_SIZE'] || 500 %>
 thread_response_default_size: <%= ENV['THREAD_RESPONSE_DEFAULT_SIZE'] || 100 %>
 thread_response_size_limit: <%= ENV['THREAD_RESPONSE_SIZE_LIMIT'] || 200 %>
+elasticsearch_index_prefix: <%= ENV['ELASTICSEARCH_INDEX_PREFIX'] || "" %>
+<% if ENV['ELASTICSEARCH_CA_PATH'] %>
+elasticsearch_transport_options:
+  ssl:
+    ca_file: <%= ENV['ELASTICSEARCH_CA_PATH'] %>
+<% else %>
+elasticsearch_transport_options: {}
+<% end %>

--- a/lib/task_helpers.rb
+++ b/lib/task_helpers.rb
@@ -6,8 +6,12 @@ module TaskHelpers
   module ElasticsearchHelper
     LOG = Logger.new(STDERR)
     INDEX_MODELS = [Comment, CommentThread].freeze
-    INDEX_NAMES = [Comment.index_name, CommentThread.index_name].freeze
     # local variable which store actual indices for future deletion
+
+    def self.index_names
+      [Comment.index_name, CommentThread.index_name].freeze
+    end
+
     @@temporary_index_names = []
 
     def self.temporary_index_names
@@ -186,7 +190,7 @@ module TaskHelpers
 
     def self.refresh_indices
       if temporary_index_names.length > 0
-        Elasticsearch::Model.client.indices.refresh(index: INDEX_NAMES)
+        Elasticsearch::Model.client.indices.refresh(index: self.index_names)
       else
         fail "No indices to refresh"
       end
@@ -194,7 +198,7 @@ module TaskHelpers
 
     def self.initialize_indices(force_new_index = false)
       # When force_new_index is true, fresh indices will be created even if it already exists.
-      if force_new_index or not exists_aliases(INDEX_NAMES)
+      if force_new_index or not exists_aliases(self.index_names)
         index_names = create_indices
         index_names.each do |index_name|
           model = get_index_model_rel(index_name)
@@ -211,7 +215,7 @@ module TaskHelpers
     # Validates that each index includes the proper mappings.
     # There is no return value, but an exception is raised if the index is invalid.
     def self.validate_indices
-      actual_mappings = Elasticsearch::Model.client.indices.get_mapping(index: INDEX_NAMES)
+      actual_mappings = Elasticsearch::Model.client.indices.get_mapping(index: self.index_names)
 
       if actual_mappings.length == 0
         fail "Indices are not exist!"

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -33,7 +33,10 @@ class Comment < Content
   index({_type: 1, comment_thread_id: 1, author_id: 1, updated_at: 1})
   index({comment_thread_id: 1, author_id: 1, created_at: 1})
 
-  index_name = "comment"
+  index_name do
+    prefix = ::CommentService.config[:elasticsearch_index_prefix]
+    "#{prefix}comments"
+  end
 
   mapping dynamic: 'false' do
     indexes :body, type: :text, store: true, term_vector: :with_positions_offsets

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -39,7 +39,10 @@ class CommentThread < Content
 
   index({ author_id: 1, course_id: 1 })
 
-  index_name = "comment_thread"
+  index_name do
+    prefix = ::CommentService.config[:elasticsearch_index_prefix]
+    "#{prefix}comment_threads"
+  end
 
   mapping dynamic: 'false' do
     indexes :title, type: :text, boost: 5.0, store: true, term_vector: :with_positions_offsets

--- a/spec/lib/tasks/search_rake_spec.rb
+++ b/spec/lib/tasks/search_rake_spec.rb
@@ -30,7 +30,7 @@ end
 
 describe "search:catchup" do
   include_context "rake"
-  let(:indices) { TaskHelpers::ElasticsearchHelper::INDEX_NAMES }
+  let(:indices) { TaskHelpers::ElasticsearchHelper::index_names }
   let(:comments_index_name) { Comment.index_name }
   let(:comment_threads_index_name) { CommentThread.index_name }
 


### PR DESCRIPTION
## Description

Adds a new configuration setting, `ELASTICSEARCH_INDEX_PREFIX`. If set, all Elasticsearch indexes and aliases that are generated by the application begin with the prefix.

This is to enable multi-tenancy, so that more than one version of this application can run on an ElasticSearch deployment.

## Testing instructions

When testing this, be sure to clear out your current `tutor` install beforehand (`tutor local stop` and `rm -r ~/.local/share/tutor`)

- Update your tutor version to at least 14.2.0: `pip install --upgrade tutor[full]`
- Install the tutor-forum plugin: `pip install git+https://github.com/open-craft/tutor-forum@keith/prefix-elasticsearch-indexes`
- Enable the plugin `tutor plugins enable forum`
- ```
  tutor config save --set ELASTICSEARCH_INDEX_PREFIX=starting_ \
     --set FORUM_REPOSITORY=https://github.com/open-craft/cs_comments_service.git \
     --set FORUM_RELEASE="keith/prefix-elasticsearch-indexes"
  ```
- `tutor images build forum` to build the forum image
- `tutor local quickstart` Create a tutor local install
- Verify that all indices contain the prefix `starting_`
  ```
  docker exec -it tutor_local-elasticsearch-1 curl http://localhost:9200/_cat/indices
  yellow open starting_comment_threads_20221212091447199 f7pYo7oDRGWWXgwxGDQoAQ 1 1 0 0 208b 208b
  yellow open starting_comments_20221212091450166        EGE-6_FpROGpDHUGXhy0ag 1 1 0 0 208b 208b
  yellow open starting_comments_20221212091447199        hXu_pX-cQ4eawUrNXYu3vg 1 1 0 0 208b 208b
  yellow open starting_comment_threads_20221212091450166 3pTwlphYQKKMCQuQMmTO9w 1 1 0 0 208b 208b
  ```
- Verify that all aliases begin with the prefix `starting_`
  ```
  docker exec -it tutor_local-elasticsearch-1 curl http://localhost:9200/_cat/aliases
  starting_comments        starting_comments_20221212103600407        - - - -
  starting_comment_threads starting_comment_threads_20221212103600407 - - - -
  ```

## Other information

I couldn't run the tests locally as the test documentation is outdated due to #392. If upstream confirms this is a worthwhile addition, I'll add tests.