### PR TITLE
fix: 500 error if paginated_stats are empty

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -71,12 +71,18 @@ get "#{APIPREFIX}/users/:course_id/stats" do |course_id|
                                          ]
                                        }}
                                      ]).to_a[0]
-    total_count = paginated_stats["pagination"][0]["total_count"]
-    num_pages = [1, (total_count / per_page.to_f).ceil].max
-    data = paginated_stats["data"].map do |user_stats|
-      {
-        :username => user_stats["username"]
-      }.merge(user_stats["course_stats"].except(*exclude_from_stats))
+    data = []
+    num_pages = 0
+    page = 0
+    total_count = 0
+    if not paginated_stats["pagination"].empty?
+      total_count = paginated_stats["pagination"][0]["total_count"]
+      num_pages = [1, (total_count / per_page.to_f).ceil].max
+      data = paginated_stats["data"].map do |user_stats|
+        {
+          :username => user_stats["username"]
+        }.merge(user_stats["course_stats"].except(*exclude_from_stats))
+      end
     end
   else
     # If a list of usernames is provided, then sort by the order in which those names appear

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -521,6 +521,14 @@ describe "app" do
         expect(res["user_stats"]).to eq expected_result
       end
 
+      it "handle stats for user with no activity" do
+        invalid_course_id = "course-v1:edX+DNE+Not_EXISTS"
+        get "/api/v1/users/#{invalid_course_id}/stats"
+        expect(last_response.status).to eq(200)
+        res = parse(last_response.body)
+        expect(res["user_stats"]).to eq []
+      end
+
       it "returns user's stats filtered by user with default/activity sort" do
         usernames = %w[userauthor-1 userauthor-2 userauthor-3].sample(2)
         usernames = usernames.shuffle.join(',')


### PR DESCRIPTION
API was returning 500 when there were no stats in a course.

Ticket Link: [INF-1067](https://2u-internal.atlassian.net/browse/INF-1067)