### PR TITLE
fix: exclude anonymous posts in build_course_stats INF-887

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -273,7 +273,7 @@ class User
     data = Content.collection.aggregate(
       [
         # Match all content in the course by the specified author
-        { "$match" => { :course_id => course_id, :author_id => self.external_id } },
+        { "$match" => { :course_id => course_id, :author_id => self.external_id, "anonymous_to_peers" => false, "anonymous" => false } },
         # Keep a count of flags for each entry
         {
           "$addFields" => {

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -684,6 +684,29 @@ describe "app" do
           expect(new_stats["active_flags"]).to eq @original_stats["active_flags"] - 1
         end
       end
+      describe "build_course_stats" do
+        let(:user) { create_test_user 3}
+        let(:course_id) { DFLT_COURSE_ID }
+
+        context 'when the user has made anonymous posts' do
+          before do
+            make_anonymous_to_peers_thread(user, "anon thread 1 by author", DFLT_COURSE_ID, "anon_thread_1")
+            make_anonymous_thread(user, "anon thread 2 by author", DFLT_COURSE_ID, "anon_thread_2")
+          end
+
+          it 'does not include anonymous posts in the counts after making a non-anonymous post' do
+
+            make_thread(user, "thread by new author #{user}", DFLT_COURSE_ID, "new_thread")
+
+            get "/api/v1/users/#{course_id}/stats"
+            expect(last_response.status).to eq(200)
+            stats = parse(last_response.body)
+            expect(stats["user_stats"][0]["replies"]).to eq(0)
+            expect(stats["user_stats"][0]["responses"]).to eq(0)
+            expect(stats["user_stats"][0]["threads"]).to eq(1)
+          end
+        end
+      end
     end
 
     describe "POST /api/v1/users/:course_id/update_stats" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -347,6 +347,24 @@ def make_thread(author, text, course_id, commentable_id, thread_type=:discussion
   thread
 end
 
+def make_anonymous_to_peers_thread(author, text, course_id, commentable_id, thread_type=:discussion, context=:course)
+  thread = CommentThread.new(title: text, body: text, course_id: course_id, commentable_id: commentable_id, anonymous_to_peers: true)
+  thread.thread_type = thread_type
+  thread.author = author
+  thread.context = context
+  thread.save!
+  thread
+end
+
+def make_anonymous_thread(author, text, course_id, commentable_id, thread_type=:discussion, context=:course)
+  thread = CommentThread.new(title: text, body: text, course_id: course_id, commentable_id: commentable_id, anonymous: true)
+  thread.thread_type = thread_type
+  thread.author = author
+  thread.context = context
+  thread.save!
+  thread
+end
+
 def make_comment(author, parent, text)
   if parent.is_a?(CommentThread)
     coll = parent.comments


### PR DESCRIPTION
**Co-Contributor:** @sohailfatima

**Ticket:** https://2u-internal.atlassian.net/browse/INF-887

**Fix:** 
Update line 276 in cs_comments_service/models/user.rb


       ` { "$match" => { :course_id => course_id, :author_id => self.external_id, "anonymous_to_peers" => false, "anonymous" => false} },`

**Explanation:** 

When a user makes their first non-anonymous post, the system uses the "build_course_stats" function to create a new set of statistics for that user. However, there is a problem with the current implementation of the function. It counts all the posts made by a specific user, including those that are anonymous or were made anonymously to peers, before the user made their first non-anonymous post. This leads to an inaccurate count of the user's threads being saved in the database. In other words, the function doesn't filter out the posts made before the user started posting non-anonymously, causing the stored count to be incorrect. 

**Note:** this fix is not backward compatible as that would require direct changes to the database.