### PR TITLE
fix: move data dog config behind flag

### DIFF
--- a/config/unicorn_tcp.rb
+++ b/config/unicorn_tcp.rb
@@ -11,12 +11,13 @@ timeout 25
 preload_app true
 
 service_name = 'forum'
-
-require 'ddtrace'
-# Add Datadog APM configuration
-Datadog.configure do |c|
-  c.tracing.instrument :rails, service_name: service_name
-  c.tracing.instrument :sinatra, service_name: service_name
+if ENV['ENABlE_DATA_DOG']
+  require 'ddtrace'
+  # Add Datadog APM configuration
+  Datadog.configure do |c|
+    c.tracing.instrument :rails, service_name: service_name
+    c.tracing.instrument :sinatra, service_name: service_name
+  end
 end
 
 listen_host = ENV['LISTEN_HOST'] || '0.0.0.0'

--- a/config/unicorn_tcp.rb
+++ b/config/unicorn_tcp.rb
@@ -11,7 +11,7 @@ timeout 25
 preload_app true
 
 service_name = 'forum'
-if ENV['ENABlE_DATA_DOG']
+if ENV['ENABLE_DATA_DOG']
   require 'ddtrace'
   # Add Datadog APM configuration
   Datadog.configure do |c|


### PR DESCRIPTION
## Description:
Move data dog configurations behind a new flag  To make sure it does not cause any issues with deployments without data dog setup.

## Ticket
https://2u-internal.atlassian.net/browse/INF-1420