### PR TITLE
Add ruby update to redwood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,9 @@ jobs:
       - name: Run tests
         run: bin/rspec -fd
         continue-on-error: ${{ matrix.allow-failure }}
+      - name: Send test coverage report to codecov.io
+        uses: codecov/codecov-action@v4
+        with:
+          lags: unittests
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,4 @@ gem "rack-contrib", :git => 'https://github.com/rack/rack-contrib.git', :ref => 
 
 
 gem "timecop", "~> 0.9.5"
+gem 'ddtrace', require: 'ddtrace/auto_instrument'

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'dalli'
 gem 'rest-client'
 
 group :test do
-  gem 'codecov', :require => false
+  gem 'simplecov-cobertura', :require => false
   gem 'mongoid_cleaner', '~> 1.2.0'
   gem 'factory_bot'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,6 @@ GEM
     bigdecimal (3.1.6)
     bson (4.15.0)
     bson_ext (1.5.1)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     crack (1.0.0)
@@ -201,10 +199,13 @@ GEM
     rspec-support (3.13.0)
     ruby2_keywords (0.0.5)
     shellany (0.0.1)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sinatra (4.0.0)
@@ -241,7 +242,6 @@ DEPENDENCIES
   bson
   bson_ext
   bundler
-  codecov
   dalli
   ddtrace
   delayed_job
@@ -272,6 +272,7 @@ DEPENDENCIES
   rspec
   rspec-collection_matchers
   rspec-its
+  simplecov-cobertura
   sinatra
   sinatra-param (~> 1.4)
   timecop (~> 0.9.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,15 @@ GEM
       bigdecimal
       rexml
     dalli (3.2.8)
+    datadog-ci (0.8.3)
+      msgpack
+    ddtrace (1.22.0)
+      datadog-ci (~> 0.8.1)
+      debase-ruby_core_source (= 3.3.1)
+      libdatadog (~> 7.0.0.1.0)
+      libddwaf (~> 1.14.0.0.0)
+      msgpack
+    debase-ruby_core_source (3.3.1)
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     delayed_job_mongoid (3.0.0)
@@ -107,6 +116,9 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     kgio (2.11.4)
+    libdatadog (7.0.0.1.0)
+    libddwaf (1.14.0.0.0)
+      ffi (~> 1.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -127,6 +139,7 @@ GEM
     mongoid_magic_counter_cache (1.1.1)
       mongoid
       rake
+    msgpack (1.7.2)
     multi_json (1.15.0)
     multipart-post (2.4.0)
     mustermann (3.0.0)
@@ -230,6 +243,7 @@ DEPENDENCIES
   bundler
   codecov
   dalli
+  ddtrace
   delayed_job
   delayed_job_mongoid
   elasticsearch (~> 7.8.0)

--- a/Gemfile3
+++ b/Gemfile3
@@ -46,7 +46,7 @@ gem 'dalli'
 gem 'rest-client'
 
 group :test do
-  gem 'codecov', :require => false
+  gem 'simplecov-cobertura', :require => false
   gem 'mongoid_cleaner', '~> 1.2.0'
   gem 'factory_bot'
   gem 'faker'

--- a/Gemfile3.lock
+++ b/Gemfile3.lock
@@ -29,8 +29,6 @@ GEM
     bigdecimal (3.1.6)
     bson (4.15.0)
     bson_ext (1.5.1)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     crack (1.0.0)
@@ -210,10 +208,13 @@ GEM
     rspec-support (3.13.0)
     ruby2_keywords (0.0.5)
     shellany (0.0.1)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sinatra (4.0.0)
@@ -245,6 +246,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -252,7 +254,6 @@ DEPENDENCIES
   bson
   bson_ext
   bundler
-  codecov
   dalli
   ddtrace
   delayed_job
@@ -284,6 +285,7 @@ DEPENDENCIES
   rspec
   rspec-collection_matchers
   rspec-its
+  simplecov-cobertura
   sinatra
   sinatra-param (~> 1.4)
   timecop (~> 0.9.5)

--- a/config/unicorn_tcp.rb
+++ b/config/unicorn_tcp.rb
@@ -11,12 +11,13 @@ timeout 25
 preload_app true
 
 service_name = 'forum'
-
-require 'ddtrace'
-# Add Datadog APM configuration
-Datadog.configure do |c|
-  c.tracing.instrument :rails, service_name: service_name
-  c.tracing.instrument :sinatra, service_name: service_name
+if ENV['ENABLE_DATA_DOG']
+  require 'ddtrace'
+  # Add Datadog APM configuration
+  Datadog.configure do |c|
+    c.tracing.instrument :rails, service_name: service_name
+    c.tracing.instrument :sinatra, service_name: service_name
+  end
 end
 
 listen_host = ENV['LISTEN_HOST'] || '0.0.0.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,8 @@ ENV["SINATRA_ENV"] = "test"
 require 'simplecov'
 SimpleCov.start
 if ENV['CI']=='true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 require File.join(File.dirname(__FILE__), '..', 'app')


### PR DESCRIPTION
This PR just to sync `master` with `open-release/redwood.master` since there are only two commits exists between cut date and now no need for backport. 

To be merged before open-release/redwood.2 release