### PR TITLE
fix: set the correct config name `connect_timout` mongoid

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -6,7 +6,7 @@ common: &default_client
       mode: :<%= ENV['MONGOID_READ_MODE'] || 'primary' %>
     max_retries: <%= ENV['MONGOID_MAX_RETRIES'] || 1 %>
     retry_interval: <%= ENV['MONGOID_RETRY_INTERVAL'] || 0 %>
-    timeout: <%= ENV['MONGOID_TIMEOUT'] || 0.5 %>
+    connect_timeout: <%= ENV['MONGOID_CONNECT_TIMEOUT'] || 0.5 %>
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
     auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] || '' %>
     auth_mech: <%= ENV['MONGOID_AUTH_MECH'].nil? ? ':scram' : ENV['MONGOID_AUTH_MECH'] %>


### PR DESCRIPTION
  This change just fix the name of the variable that is
  respoinsbile for:
  > The time to wait to establish a connection before timing out,
  >  in seconds

  ref: https://www.mongodb.com/docs/offline/mongoid-7.5.tar.gz